### PR TITLE
Improve docker-run.sh: auto-pull, consolidated flags, and docs restructure

### DIFF
--- a/docker-logs.sh
+++ b/docker-logs.sh
@@ -1,7 +1,0 @@
-#!/usr/bin/env bash
-set -euo pipefail
-
-CONTAINER_NAME="embabel-demo"
-
-echo "Following logs for ${CONTAINER_NAME}... Press Control+C to exit."
-docker logs -f "${CONTAINER_NAME}"

--- a/docker-run.sh
+++ b/docker-run.sh
@@ -6,14 +6,14 @@ PORT="48080"
 CONTAINER_NAME="embabel-demo"
 
 # Stop and remove the container
-if [ "${1:-}" = "stop" ]; then
+if [ "${1:-}" = "--stop" ] || [ "${1:-}" = "-s" ]; then
   echo "Stopping ${CONTAINER_NAME}..."
   docker rm -f "${CONTAINER_NAME}" 2>/dev/null || echo "Container not running."
   exit 0
 fi
 
 # Pull the latest image unless --run-only is specified
-if [ "${1:-}" = "--run-only" ]; then
+if [ "${1:-}" = "--run-only" ] || [ "${1:-}" = "-r" ]; then
   shift
 else
   echo "Pulling ${IMAGE}..."
@@ -47,5 +47,5 @@ echo "Starting ${IMAGE} on port ${PORT}..."
 docker run -d "${ARGS[@]}" "${IMAGE}"
 
 echo "Following logs... Press Control+C to exit (container will keep running)."
-echo "To stop: ./docker-run.sh stop"
+echo "To stop: ./docker-run.sh --stop"
 docker logs -f "${CONTAINER_NAME}"

--- a/docker-run.sh
+++ b/docker-run.sh
@@ -12,6 +12,14 @@ if [ "${1:-}" = "stop" ]; then
   exit 0
 fi
 
+# Pull the latest image unless --no-pull is specified
+if [ "${1:-}" = "--no-pull" ]; then
+  shift
+else
+  echo "Pulling ${IMAGE}..."
+  docker pull "${IMAGE}"
+fi
+
 # Build docker run arguments
 ARGS=("-p" "${PORT}:8080" "--name" "${CONTAINER_NAME}")
 

--- a/docker-run.sh
+++ b/docker-run.sh
@@ -12,8 +12,8 @@ if [ "${1:-}" = "stop" ]; then
   exit 0
 fi
 
-# Pull the latest image unless --no-pull is specified
-if [ "${1:-}" = "--no-pull" ]; then
+# Pull the latest image unless --run-only is specified
+if [ "${1:-}" = "--run-only" ]; then
   shift
 else
   echo "Pulling ${IMAGE}..."

--- a/docker-run.sh
+++ b/docker-run.sh
@@ -12,6 +12,13 @@ if [ "${1:-}" = "--stop" ] || [ "${1:-}" = "-s" ]; then
   exit 0
 fi
 
+# Follow logs for an already-running container
+if [ "${1:-}" = "--logs" ] || [ "${1:-}" = "-l" ]; then
+  echo "Following logs for ${CONTAINER_NAME}... Press Control+C to exit."
+  docker logs -f "${CONTAINER_NAME}"
+  exit 0
+fi
+
 # Pull the latest image unless --run-only is specified
 if [ "${1:-}" = "--run-only" ] || [ "${1:-}" = "-r" ]; then
   shift

--- a/docs/docker-compose.md
+++ b/docs/docker-compose.md
@@ -4,19 +4,21 @@
 
 # Docker Compose
 
-You can run this project in Docker using Docker Compose. The Docker build
-uses the `all` Maven profile and runs with `config/all`.
+Docker Compose builds from source and runs the application locally. The
+Docker build uses the `all` Maven profile and runs with `config/all`.
 
 Set the environment variables for your model provider
-(if not already in your `~/.zshrc`):
+(if not already in your `~/.zshrc` — see [Setup](setup.md) for details):
 
 **Anthropic:**
+
 ```bash
 export ANTHROPIC_BASE_URL=https://<your-private-anthropic-domain>
 export ANTHROPIC_API_KEY=<your-api-key>
 ```
 
 **OpenAI:**
+
 ```bash
 export OPENAI_BASE_URL=https://<your-private-openai-domain>
 export OPENAI_API_KEY=<your-api-key>
@@ -29,6 +31,7 @@ on the host machine.
 
 On Linux (without Docker Desktop), you may need to set
 `OLLAMA_HOST=0.0.0.0` so Ollama listens on all interfaces:
+
 ```bash
 export OLLAMA_HOST=0.0.0.0
 ollama serve
@@ -40,6 +43,7 @@ variables you have not exported will be passed as empty strings,
 which is safe because the application ignores empty values.
 
 Build and start the service:
+
 ```bash
 docker compose up --build
 ```
@@ -47,6 +51,7 @@ docker compose up --build
 The service will be available at `http://localhost:48080`.
 
 To stop the service:
+
 ```bash
 docker compose down
 ```
@@ -66,11 +71,11 @@ docker compose run \
 
 Available models include:
 
-| Provider  | Models                                      |
-|-----------|---------------------------------------------|
-| Anthropic | `claude-opus-4-1`, `claude-sonnet-4-5`      |
-| OpenAI    | `gpt-4.1`, `gpt-4.1-mini`                  |
-| Ollama    | `gpt-oss:20b`, `qwen3:4b`                  |
+| Provider  | Models                                 |
+|-----------|----------------------------------------|
+| Anthropic | `claude-opus-4-1`, `claude-sonnet-4-5` |
+| OpenAI    | `gpt-4.1`, `gpt-4.1-mini`             |
+| Ollama    | `gpt-oss:20b`, `qwen3:4b`             |
 
 ## MCP Server
 

--- a/docs/docker.md
+++ b/docs/docker.md
@@ -47,12 +47,12 @@ starts the container on port 48080 (4 looks like **e** for Embabel),
 and follows the logs. It automatically passes through any provider
 environment variables that are set.
 
-| Command                      | Short   | Description                          |
-|------------------------------|---------|--------------------------------------|
-| `./docker-run.sh`           |         | Pull the latest image and run        |
-| `./docker-run.sh --run-only`| `-r`    | Run without pulling                  |
-| `./docker-run.sh --stop`    | `-s`    | Stop and remove the container        |
-| `./docker-logs.sh`          |         | Follow the container logs            |
+| Command                       | Short | Description                   |
+|-------------------------------|-------|-------------------------------|
+| `./docker-run.sh`            |       | Pull the latest image and run |
+| `./docker-run.sh --run-only` | `-r`  | Run without pulling           |
+| `./docker-run.sh --logs`     | `-l`  | Follow the container logs     |
+| `./docker-run.sh --stop`     | `-s`  | Stop and remove the container |
 
 The script detects which provider variables (`ANTHROPIC_BASE_URL`,
 `ANTHROPIC_API_KEY`, `OPENAI_BASE_URL`, `OPENAI_API_KEY`) are set in

--- a/docs/docker.md
+++ b/docs/docker.md
@@ -47,29 +47,12 @@ starts the container on port 48080 (4 looks like **e** for Embabel),
 and follows the logs. It automatically passes through any provider
 environment variables that are set.
 
-Pull the latest image and run:
-
-```bash
-./docker-run.sh
-```
-
-Run without pulling (use the existing local image):
-
-```bash
-./docker-run.sh --run-only
-```
-
-Follow the container logs (if you exited with Control+C):
-
-```bash
-./docker-logs.sh
-```
-
-Stop and remove the container:
-
-```bash
-./docker-run.sh stop
-```
+| Command                      | Short   | Description                          |
+|------------------------------|---------|--------------------------------------|
+| `./docker-run.sh`           |         | Pull the latest image and run        |
+| `./docker-run.sh --run-only`| `-r`    | Run without pulling                  |
+| `./docker-run.sh --stop`    | `-s`    | Stop and remove the container        |
+| `./docker-logs.sh`          |         | Follow the container logs            |
 
 The script detects which provider variables (`ANTHROPIC_BASE_URL`,
 `ANTHROPIC_API_KEY`, `OPENAI_BASE_URL`, `OPENAI_API_KEY`) are set in

--- a/docs/docker.md
+++ b/docs/docker.md
@@ -4,23 +4,20 @@
 
 # Docker
 
-## Pulling from Docker Hub
-
-Pull and run the latest image directly from Docker Hub:
-```bash
-docker pull stevendoolan/embabel-demo:latest
-```
+## Prerequisites
 
 Set the environment variables for your model provider
 (see [Setup](setup.md) for details):
 
 **Anthropic:**
+
 ```bash
 export ANTHROPIC_BASE_URL=https://<your-private-anthropic-domain>
 export ANTHROPIC_API_KEY=<your-api-key>
 ```
 
 **OpenAI:**
+
 ```bash
 export OPENAI_BASE_URL=https://<your-private-openai-domain>
 export OPENAI_API_KEY=<your-api-key>
@@ -33,6 +30,7 @@ on the host machine.
 
 On Linux (without Docker Desktop), you may need to set
 `OLLAMA_HOST=0.0.0.0` so Ollama listens on all interfaces:
+
 ```bash
 export OLLAMA_HOST=0.0.0.0
 ollama serve
@@ -42,28 +40,32 @@ To make these permanent, add them to your `~/.zshrc` file.
 Do not pass API keys directly on the command line as they may be
 visible in shell history and process listings.
 
-Run the container using the convenience script (port 48080 — 4 looks
-like **e** for Embabel). The script pulls the latest image and
-automatically passes through any provider environment variables that
-are set:
+## Using the scripts
+
+The `docker-run.sh` script pulls the latest image from Docker Hub,
+starts the container on port 48080 (4 looks like **e** for Embabel),
+and follows the logs. It automatically passes through any provider
+environment variables that are set.
+
+Pull the latest image and run:
 
 ```bash
 ./docker-run.sh
 ```
 
-To skip the pull and run the existing local image:
+Run without pulling (use the existing local image):
 
 ```bash
 ./docker-run.sh --run-only
 ```
 
-To follow the container logs:
+Follow the container logs (if you exited with Control+C):
 
 ```bash
 ./docker-logs.sh
 ```
 
-To stop and remove the container:
+Stop and remove the container:
 
 ```bash
 ./docker-run.sh stop
@@ -77,47 +79,70 @@ forwards optional model override variables if set (see
 The container is named `embabel-demo` — restarting the script
 automatically removes any existing container with that name.
 
-### Running manually
+The service will be available at `http://localhost:48080`.
 
-Alternatively, run `docker run` directly, passing the environment
-variables for your chosen provider(s):
+## Manual fallback commands
+
+If you prefer to run the commands manually, here is what the scripts do
+under the hood.
+
+Pull the latest image:
+
+```bash
+docker pull stevendoolan/embabel-demo:latest
+```
 
 **All providers (Anthropic + OpenAI):**
+
 ```bash
-docker run -p 48080:8080 \
+docker run -d -p 48080:8080 \
   -e ANTHROPIC_BASE_URL \
   -e ANTHROPIC_API_KEY \
   -e OPENAI_BASE_URL \
   -e OPENAI_API_KEY \
+  --name embabel-demo \
   stevendoolan/embabel-demo:latest
 ```
 
 **Anthropic:**
+
 ```bash
-docker run -p 48080:8080 \
+docker run -d -p 48080:8080 \
   -e ANTHROPIC_BASE_URL \
   -e ANTHROPIC_API_KEY \
+  --name embabel-demo \
   stevendoolan/embabel-demo:latest
 ```
 
 **OpenAI:**
+
 ```bash
-docker run -p 48080:8080 \
+docker run -d -p 48080:8080 \
   -e OPENAI_BASE_URL \
   -e OPENAI_API_KEY \
+  --name embabel-demo \
   stevendoolan/embabel-demo:latest
 ```
 
 **Ollama:**
+
 ```bash
-docker run -p 48080:8080 \
+docker run -d -p 48080:8080 \
+  --name embabel-demo \
   stevendoolan/embabel-demo:latest
 ```
 
 On Linux (without Docker Desktop), add `--add-host=host.docker.internal:host-gateway`
 so the container can reach Ollama on the host.
 
-To stop and remove a manually started container:
+Follow the logs:
+
+```bash
+docker logs -f embabel-demo
+```
+
+Stop and remove:
+
 ```bash
 docker rm -f embabel-demo
 ```
@@ -126,30 +151,29 @@ docker rm -f embabel-demo
 > Passing an unset variable with `-e` sends an empty string to the
 > container, which may cause the provider client to fail.
 
-### Overriding the default models
+## Overriding the default models
 
 The Docker image defaults to `claude-sonnet-4-5` as the default LLM.
 You can override the models using environment variables:
 
 ```bash
-docker run -p 48080:8080 \
+docker run -d -p 48080:8080 \
   -e EMBABEL_MODELS_DEFAULT_LLM=gpt-4.1 \
   -e EMBABEL_MODELS_LLMS_BEST=gpt-4.1 \
   -e EMBABEL_MODELS_LLMS_CHEAPEST=gpt-4.1-mini \
   -e OPENAI_BASE_URL \
   -e OPENAI_API_KEY \
+  --name embabel-demo \
   stevendoolan/embabel-demo:latest
 ```
 
 Available models include:
 
-| Provider  | Models                                      |
-|-----------|---------------------------------------------|
-| Anthropic | `claude-opus-4-1`, `claude-sonnet-4-5`      |
-| OpenAI    | `gpt-4.1`, `gpt-4.1-mini`                  |
-| Ollama    | `gpt-oss:20b`, `qwen3:4b`                  |
-
-The service will be available at `http://localhost:48080`.
+| Provider  | Models                                 |
+|-----------|----------------------------------------|
+| Anthropic | `claude-opus-4-1`, `claude-sonnet-4-5` |
+| OpenAI    | `gpt-4.1`, `gpt-4.1-mini`             |
+| Ollama    | `gpt-oss:20b`, `qwen3:4b`             |
 
 ## MCP Server via Docker Hub
 
@@ -161,15 +185,17 @@ at `http://localhost:48080/sse`.
 
 The following tools are available:
 
-| Tool Name             | Agent                                                        | Description                                                |
-|-----------------------|--------------------------------------------------------------|------------------------------------------------------------|
-| `fibonacciNumbers`    | [FibonacciAgent](agents/fibonacci-agent.md)                  | Compute Fibonacci numbers using LLM with tool verification |
-| `writeAndReviewStory` | [WriteAndReviewAgent](agents/write-and-review-agent.md)      | Generate a story and review it                             |
-| `bestDadJoke`         | [BestDadJokeAgent](agents/best-dad-joke-agent.md)            | Create the best dad joke ever                              |
-| `sonicPiCode`         | [SonicPiAgent](agents/sonic-pi-agent.md)                     | Generate Sonic Pi code from user input (not yet working via MCP) |
+| Tool Name             | Agent                                                   | Description                                                |
+|-----------------------|---------------------------------------------------------|------------------------------------------------------------|
+| `fibonacciNumbers`    | [FibonacciAgent](agents/fibonacci-agent.md)             | Compute Fibonacci numbers using LLM with tool verification |
+| `writeAndReviewStory` | [WriteAndReviewAgent](agents/write-and-review-agent.md) | Generate a story and review it                             |
+| `bestDadJoke`         | [BestDadJokeAgent](agents/best-dad-joke-agent.md)       | Create the best dad joke ever                              |
+| `sonicPiCode`         | [SonicPiAgent](agents/sonic-pi-agent.md)                | Generate Sonic Pi code from user input (not yet working via MCP) |
 
 ### Claude Code
+
 Add the MCP server to your global Claude Code config at `~/.claude.json`:
+
 ```json
 {
   "mcpServers": {
@@ -187,12 +213,15 @@ The 10-minute timeout (600000ms) is recommended because some agents
 
 Alternatively, add via the CLI (note: this does not set the timeout,
 so you will need to edit `~/.claude.json` afterwards to add it):
+
 ```bash
 claude mcp add embabel-demo --transport sse http://localhost:48080/sse
 ```
 
 ### GitHub Copilot
+
 Add a `.vscode/mcp.json` file to your project root:
+
 ```json
 {
   "servers": {
@@ -206,6 +235,7 @@ Add a `.vscode/mcp.json` file to your project root:
 ```
 
 ### IntelliJ IDEA / JetBrains AI Assistant
+
 Use the SSE URL `http://localhost:48080/sse` when configuring the MCP
 server. See [Docker Compose](docker-compose.md) for detailed setup steps.
 

--- a/docs/docker.md
+++ b/docs/docker.md
@@ -43,19 +43,28 @@ Do not pass API keys directly on the command line as they may be
 visible in shell history and process listings.
 
 Run the container using the convenience script (port 48080 — 4 looks
-like **e** for Embabel). The script automatically passes through any
-provider environment variables that are set:
+like **e** for Embabel). The script pulls the latest image and
+automatically passes through any provider environment variables that
+are set:
 
 ```bash
 ./docker-run.sh
 ```
 
+To skip the pull and run the existing local image:
+
+```bash
+./docker-run.sh --run-only
+```
+
 To follow the container logs:
+
 ```bash
 ./docker-logs.sh
 ```
 
 To stop and remove the container:
+
 ```bash
 ./docker-run.sh stop
 ```


### PR DESCRIPTION
## Summary

- `docker-run.sh` now pulls the latest image before running (default behaviour)
- Merged `docker-logs.sh` into `docker-run.sh` as `--logs`/`-l` flag and deleted the standalone script
- All arguments use consistent GNU-style `--long` flags with `-short` aliases:
  | Command                       | Short | Description                   |
  |-------------------------------|-------|-------------------------------|
  | `./docker-run.sh`            |       | Pull the latest image and run |
  | `./docker-run.sh --run-only` | `-r`  | Run without pulling           |
  | `./docker-run.sh --logs`     | `-l`  | Follow the container logs     |
  | `./docker-run.sh --stop`     | `-s`  | Stop and remove the container |
- Restructured docker docs to lead with scripts, manual docker commands as fallback

## Test plan

- [ ] Run `./docker-run.sh` — verify it pulls then starts the container
- [ ] Run `./docker-run.sh -r` — verify it skips the pull
- [ ] Run `./docker-run.sh -l` — verify it follows logs
- [ ] Run `./docker-run.sh -s` — verify it stops the container

🤖 Generated with [Claude Code](https://claude.com/claude-code)