### PR TITLE
Align markdown table columns consistently across docs

### DIFF
--- a/docs/agents/best-dad-joke-agent.md
+++ b/docs/agents/best-dad-joke-agent.md
@@ -14,9 +14,9 @@ Inspired by the [Coffee + Software](https://www.youtube.com/watch?v=kpeYvKha5oE&
 
 ## Configuration
 
-| Property | Default | Description |
-|----------|---------|-------------|
-| `bestdadjoke.joke-count` | 5 | Number of jokes to generate |
+| Property                 | Default | Description                 |
+|--------------------------|---------|-----------------------------|
+| `bestdadjoke.joke-count` | 5       | Number of jokes to generate |
 
 ## Action Flow
 
@@ -50,11 +50,11 @@ JokesAndRatings
 
 ## Actions
 
-| # | Action | Input | Output | Description |
-|---|--------|-------|--------|-------------|
-| 1 | `writeJokes` | `UserInput` | `Jokes` | Uses LLM to generate N dad jokes based on user input |
-| 2 | `rateJokes` | `Jokes` | `JokesAndRatings` | Rates each joke in parallel using LLM |
-| 3 | `createBestDadJoke` | `JokesAndRatings` | `BestDadJokeResult` | Selects the highest-rated joke as the best |
+| # | Action              | Input             | Output              | Description                                          |
+|---|---------------------|-------------------|---------------------|------------------------------------------------------|
+| 1 | `writeJokes`        | `UserInput`       | `Jokes`             | Uses LLM to generate N dad jokes based on user input |
+| 2 | `rateJokes`         | `Jokes`           | `JokesAndRatings`   | Rates each joke in parallel using LLM                |
+| 3 | `createBestDadJoke` | `JokesAndRatings` | `BestDadJokeResult` | Selects the highest-rated joke as the best           |
 
 ---
 

--- a/docs/agents/fibonacci-agent.md
+++ b/docs/agents/fibonacci-agent.md
@@ -51,12 +51,12 @@ FibonacciResponse    FibonacciResponse
 
 ## Actions
 
-| # | Action | Input | Output | Description |
-|---|--------|-------|--------|-------------|
-| 1 | `toFibonacciRequest` | `UserInput` | `FibonacciRequest` | Converts user input into a structured request using LLM |
-| 2 | `fibonacciWithTool` | `FibonacciRequest` | `FibonacciResponseWithTool` | Computes Fibonacci using the FibonacciCalculator tool via LLM |
-| 3 | `fibonacciWithExplanation` | `FibonacciRequest` | `FibonacciResponseWithExplanation` | Computes Fibonacci with LLM and provides explanation |
-| 4 | `fibonacciWithVerification` | `FibonacciResponseWithTool`, `FibonacciResponseWithExplanation` | `FibonacciResponseWithVerification` | Verifies both methods produced the same result |
+| # | Action                      | Input                                                           | Output                              | Description                                                   |
+|---|-----------------------------|-----------------------------------------------------------------|-------------------------------------|---------------------------------------------------------------|
+| 1 | `toFibonacciRequest`        | `UserInput`                                                     | `FibonacciRequest`                  | Converts user input into a structured request using LLM       |
+| 2 | `fibonacciWithTool`         | `FibonacciRequest`                                              | `FibonacciResponseWithTool`         | Computes Fibonacci using the FibonacciCalculator tool via LLM |
+| 3 | `fibonacciWithExplanation`  | `FibonacciRequest`                                              | `FibonacciResponseWithExplanation`  | Computes Fibonacci with LLM and provides explanation          |
+| 4 | `fibonacciWithVerification` | `FibonacciResponseWithTool`, `FibonacciResponseWithExplanation` | `FibonacciResponseWithVerification` | Verifies both methods produced the same result                |
 
 ---
 

--- a/docs/agents/index.md
+++ b/docs/agents/index.md
@@ -6,12 +6,12 @@
 
 Documentation for each agent in the `com.embabel.demo.agent` package.
 
-| Agent | Description | MCP Export |
-|-------|-------------|------------|
-| [Best Dad Joke Agent](best-dad-joke-agent.md) | Generate and rate dad jokes, then select the best one | `bestDadJoke` |
-| [Fibonacci Agent](fibonacci-agent.md) | Compute Fibonacci numbers using LLM with tool verification | `fibonacciNumbers` |
-| [Sonic Pi Agent](sonic-pi-agent.md) | Generate Sonic Pi code to play a melody based on user input | Not yet working via MCP |
-| [Write and Review Agent](write-and-review-agent.md) | Generate stories, review them, and return the best one | `writeAndReviewStory` |
+| Agent                                               | Description                                                 | MCP Export              |
+|-----------------------------------------------------|-------------------------------------------------------------|-------------------------|
+| [Best Dad Joke Agent](best-dad-joke-agent.md)       | Generate and rate dad jokes, then select the best one       | `bestDadJoke`           |
+| [Fibonacci Agent](fibonacci-agent.md)               | Compute Fibonacci numbers using LLM with tool verification  | `fibonacciNumbers`      |
+| [Sonic Pi Agent](sonic-pi-agent.md)                 | Generate Sonic Pi code to play a melody based on user input | Not yet working via MCP |
+| [Write and Review Agent](write-and-review-agent.md) | Generate stories, review them, and return the best one      | `writeAndReviewStory`   |
 
 ---
 

--- a/docs/docker-compose.md
+++ b/docs/docker-compose.md
@@ -74,8 +74,8 @@ Available models include:
 | Provider  | Models                                 |
 |-----------|----------------------------------------|
 | Anthropic | `claude-opus-4-1`, `claude-sonnet-4-5` |
-| OpenAI    | `gpt-4.1`, `gpt-4.1-mini`             |
-| Ollama    | `gpt-oss:20b`, `qwen3:4b`             |
+| OpenAI    | `gpt-4.1`, `gpt-4.1-mini`              |
+| Ollama    | `gpt-oss:20b`, `qwen3:4b`              |
 
 ## MCP Server
 
@@ -89,12 +89,12 @@ via an SSE endpoint at `http://localhost:48080/sse`.
 
 The following tools are available:
 
-| Tool Name             | Agent                                                        | Description                                                |
-|-----------------------|--------------------------------------------------------------|------------------------------------------------------------|
-| `fibonacciNumbers`    | [FibonacciAgent](agents/fibonacci-agent.md)                  | Compute Fibonacci numbers using LLM with tool verification |
-| `writeAndReviewStory` | [WriteAndReviewAgent](agents/write-and-review-agent.md)      | Generate a story and review it                             |
-| `bestDadJoke`         | [BestDadJokeAgent](agents/best-dad-joke-agent.md)            | Create the best dad joke ever                              |
-| `sonicPiCode`         | [SonicPiAgent](agents/sonic-pi-agent.md)                     | Generate Sonic Pi code from user input (not yet working via MCP) |
+| Tool Name             | Agent                                                   | Description                                                      |
+|-----------------------|---------------------------------------------------------|------------------------------------------------------------------|
+| `fibonacciNumbers`    | [FibonacciAgent](agents/fibonacci-agent.md)             | Compute Fibonacci numbers using LLM with tool verification       |
+| `writeAndReviewStory` | [WriteAndReviewAgent](agents/write-and-review-agent.md) | Generate a story and review it                                   |
+| `bestDadJoke`         | [BestDadJokeAgent](agents/best-dad-joke-agent.md)       | Create the best dad joke ever                                    |
+| `sonicPiCode`         | [SonicPiAgent](agents/sonic-pi-agent.md)                | Generate Sonic Pi code from user input (not yet working via MCP) |
 
 ## Claude Code
 Start the embabel-demo service, then add the MCP server to your

--- a/docs/docker.md
+++ b/docs/docker.md
@@ -47,8 +47,8 @@ starts the container on port 48080 (4 looks like **e** for Embabel),
 and follows the logs. It automatically passes through any provider
 environment variables that are set.
 
-| Command                       | Short | Description                   |
-|-------------------------------|-------|-------------------------------|
+| Command                      | Short | Description                   |
+|------------------------------|-------|-------------------------------|
 | `./docker-run.sh`            |       | Pull the latest image and run |
 | `./docker-run.sh --run-only` | `-r`  | Run without pulling           |
 | `./docker-run.sh --logs`     | `-l`  | Follow the container logs     |
@@ -168,11 +168,11 @@ at `http://localhost:48080/sse`.
 
 The following tools are available:
 
-| Tool Name             | Agent                                                   | Description                                                |
-|-----------------------|---------------------------------------------------------|------------------------------------------------------------|
-| `fibonacciNumbers`    | [FibonacciAgent](agents/fibonacci-agent.md)             | Compute Fibonacci numbers using LLM with tool verification |
-| `writeAndReviewStory` | [WriteAndReviewAgent](agents/write-and-review-agent.md) | Generate a story and review it                             |
-| `bestDadJoke`         | [BestDadJokeAgent](agents/best-dad-joke-agent.md)       | Create the best dad joke ever                              |
+| Tool Name             | Agent                                                   | Description                                                      |
+|-----------------------|---------------------------------------------------------|------------------------------------------------------------------|
+| `fibonacciNumbers`    | [FibonacciAgent](agents/fibonacci-agent.md)             | Compute Fibonacci numbers using LLM with tool verification       |
+| `writeAndReviewStory` | [WriteAndReviewAgent](agents/write-and-review-agent.md) | Generate a story and review it                                   |
+| `bestDadJoke`         | [BestDadJokeAgent](agents/best-dad-joke-agent.md)       | Create the best dad joke ever                                    |
 | `sonicPiCode`         | [SonicPiAgent](agents/sonic-pi-agent.md)                | Generate Sonic Pi code from user input (not yet working via MCP) |
 
 ### Claude Code


### PR DESCRIPTION
## Summary
- Standardise markdown table column alignment across all docs pages for consistent formatting
- Affected files: agent docs (best-dad-joke, fibonacci, index), docker.md, docker-compose.md

## Test plan
- [ ] Verify tables render correctly on GitHub

🤖 Generated with [Claude Code](https://claude.com/claude-code)