### PR TITLE
Rename WriteAndReviewAgent to StoryAgent and simplify story endpoint

### DIFF
--- a/docs/agents/index.md
+++ b/docs/agents/index.md
@@ -11,7 +11,7 @@ Documentation for each agent in the `com.embabel.demo.agent` package.
 | [Dad Joke Agent](dad-joke-agent.md)                 | Generate and rate dad jokes, then select the best one       | `dadJoke`               |
 | [Fibonacci Agent](fibonacci-agent.md)               | Compute Fibonacci numbers using LLM with tool verification  | `fibonacciNumbers`      |
 | [Sonic Pi Agent](sonic-pi-agent.md)                 | Generate Sonic Pi code to play a melody based on user input | Not yet working via MCP |
-| [Write and Review Agent](write-and-review-agent.md) | Generate stories, review them, and return the best one      | `writeAndReviewStory`   |
+| [Story Agent](story-agent.md)                       | Generate stories, review them, and return the best one      | `story`                 |
 
 ---
 

--- a/docs/agents/sonic-pi-agent.md
+++ b/docs/agents/sonic-pi-agent.md
@@ -1,6 +1,6 @@
 # Sonic Pi Agent
 
-[Previous: Fibonacci Agent](fibonacci-agent.md) | [Index](index.md) | [Next: Write and Review Agent](write-and-review-agent.md)
+[Previous: Fibonacci Agent](fibonacci-agent.md) | [Index](index.md) | [Next: Story Agent](story-agent.md)
 
 ---
 
@@ -81,4 +81,4 @@ SonicPiScript   SonicPiScript
 
 ---
 
-[Previous: Fibonacci Agent](fibonacci-agent.md) | [Index](index.md) | [Next: Write and Review Agent](write-and-review-agent.md)
+[Previous: Fibonacci Agent](fibonacci-agent.md) | [Index](index.md) | [Next: Story Agent](story-agent.md)

--- a/docs/agents/story-agent.md
+++ b/docs/agents/story-agent.md
@@ -1,14 +1,14 @@
-# Write and Review Agent
+# Story Agent
 
 [Previous: Sonic Pi Agent](sonic-pi-agent.md) | [Index](index.md) | [Next: Index](index.md)
 
 ---
 
-**Source:** [`WriteAndReviewAgent.java`](../../src/main/java/com/embabel/demo/agent/WriteAndReviewAgent.java)
+**Source:** [`StoryAgent.java`](../../src/main/java/com/embabel/demo/agent/StoryAgent.java)
 
 **Description:** Generate stories based on user input, review them, and return the best one.
 
-**MCP Export:** `writeAndReviewStory`
+**MCP Export:** `story`
 
 Based on the [java-agent-template WriteAndReviewAgent](https://github.com/embabel/java-agent-template/blob/main/src/main/java/com/embabel/template/agent/WriteAndReviewAgent.java). Uses different LLM roles for writing (best quality, high temperature) and reviewing (cheapest, low temperature), with retry logic for resilience.
 

--- a/docs/docker-compose.md
+++ b/docs/docker-compose.md
@@ -85,14 +85,14 @@ This application is also an MCP (Model Context Protocol) server.
 When the service is running, all agents with `@Export(remote = true)` are automatically exposed as MCP tools
 via an SSE endpoint at `http://localhost:48080/sse`.
 
-> **Note:** Some MCP tools (e.g. `writeAndReviewStory`) are long-running and may time out in JetBrains AI Assistant. For these calls, use Claude Code directly instead.
+> **Note:** Some MCP tools (e.g. `story`) are long-running and may time out in JetBrains AI Assistant. For these calls, use Claude Code directly instead.
 
 The following tools are available:
 
 | Tool Name             | Agent                                                   | Description                                                      |
 |-----------------------|---------------------------------------------------------|------------------------------------------------------------------|
 | `fibonacciNumbers`    | [FibonacciAgent](agents/fibonacci-agent.md)             | Compute Fibonacci numbers using LLM with tool verification       |
-| `writeAndReviewStory` | [WriteAndReviewAgent](agents/write-and-review-agent.md) | Generate a story and review it                                   |
+| `story`               | [StoryAgent](agents/story-agent.md)                     | Generate a story and review it                                   |
 | `dadJoke`             | [DadJokeAgent](agents/dad-joke-agent.md)                | Create a dad joke                                                |
 | `sonicPiCode`         | [SonicPiAgent](agents/sonic-pi-agent.md)                | Generate Sonic Pi code from user input (not yet working via MCP) |
 
@@ -112,7 +112,7 @@ global Claude Code config at `~/.claude.json`:
 ```
 
 The 10-minute timeout (600000ms) is recommended because some agents
-(e.g. `sonicPiCode`, `writeAndReviewStory`) are long-running.
+(e.g. `sonicPiCode`, `story`) are long-running.
 
 Alternatively, add via the CLI (note: this does not set the timeout,
 so you will need to edit `~/.claude.json` afterwards to add it):
@@ -136,8 +136,8 @@ If Claude Code doesn't use the MCP tool, try being explicit:
 Use the embabel-demo MCP server to tell me a dad joke about recursion.
 ```
 
-### Example: Write and Review Story
-Use the `writeAndReviewStory` tool to generate a story from an incident chat log and save the output:
+### Example: Story
+Use the `story` tool to generate a story from an incident chat log and save the output:
 ```
 Write a story about the incident at @docs/examples/incident-chat.md. Save the result to incident-story.md.
 ```

--- a/docs/docker.md
+++ b/docs/docker.md
@@ -171,7 +171,7 @@ The following tools are available:
 | Tool Name             | Agent                                                   | Description                                                      |
 |-----------------------|---------------------------------------------------------|------------------------------------------------------------------|
 | `fibonacciNumbers`    | [FibonacciAgent](agents/fibonacci-agent.md)             | Compute Fibonacci numbers using LLM with tool verification       |
-| `writeAndReviewStory` | [WriteAndReviewAgent](agents/write-and-review-agent.md) | Generate a story and review it                                   |
+| `story`               | [StoryAgent](agents/story-agent.md)                     | Generate a story and review it                                   |
 | `dadJoke`             | [DadJokeAgent](agents/dad-joke-agent.md)                | Create a dad joke                                                |
 | `sonicPiCode`         | [SonicPiAgent](agents/sonic-pi-agent.md)                | Generate Sonic Pi code from user input (not yet working via MCP) |
 
@@ -192,7 +192,7 @@ Add the MCP server to your global Claude Code config at `~/.claude.json`:
 ```
 
 The 10-minute timeout (600000ms) is recommended because some agents
-(e.g. `sonicPiCode`, `writeAndReviewStory`) are long-running.
+(e.g. `sonicPiCode`, `story`) are long-running.
 
 Alternatively, add via the CLI (note: this does not set the timeout,
 so you will need to edit `~/.claude.json` afterwards to add it):

--- a/postman/embabel-demo.postman_collection.json
+++ b/postman/embabel-demo.postman_collection.json
@@ -86,6 +86,21 @@
 		},
 		{
 			"name": "Sonic Pi - Generate",
+			"event": [
+				{
+					"listen": "test",
+					"script": {
+						"type": "text/javascript",
+						"exec": [
+							"var jsonData = pm.response.json();",
+							"if (jsonData.jobId) {",
+							"    pm.collectionVariables.set('jobId', jsonData.jobId);",
+							"    console.log('Set jobId to: ' + jsonData.jobId);",
+							"}"
+						]
+					}
+				}
+			],
 			"request": {
 				"method": "POST",
 				"header": [],

--- a/postman/embabel-demo.postman_collection.json
+++ b/postman/embabel-demo.postman_collection.json
@@ -37,14 +37,14 @@
 				"method": "GET",
 				"header": [],
 				"url": {
-					"raw": "http://localhost:8080/write-a-story?about=Steven",
+					"raw": "http://localhost:8080/story?about=Steven",
 					"protocol": "http",
 					"host": [
 						"localhost"
 					],
 					"port": "8080",
 					"path": [
-						"write-a-story"
+						"story"
 					],
 					"query": [
 						{

--- a/postman/embabel-demo.postman_collection.json
+++ b/postman/embabel-demo.postman_collection.json
@@ -85,6 +85,51 @@
 			"response": []
 		},
 		{
+			"name": "Sonic Pi - Generate",
+			"request": {
+				"method": "POST",
+				"header": [],
+				"url": {
+					"raw": "http://localhost:8080/sonic-pi?prompt=frank sinatra croon",
+					"protocol": "http",
+					"host": [
+						"localhost"
+					],
+					"port": "8080",
+					"path": [
+						"sonic-pi"
+					],
+					"query": [
+						{
+							"key": "prompt",
+							"value": "frank sinatra croon"
+						}
+					]
+				}
+			},
+			"response": []
+		},
+		{
+			"name": "Sonic Pi - Job Status",
+			"request": {
+				"method": "GET",
+				"header": [],
+				"url": {
+					"raw": "http://localhost:8080/sonic-pi/{{jobId}}",
+					"protocol": "http",
+					"host": [
+						"localhost"
+					],
+					"port": "8080",
+					"path": [
+						"sonic-pi",
+						"{{jobId}}"
+					]
+				}
+			},
+			"response": []
+		},
+		{
 			"name": "Fibonacci",
 			"request": {
 				"method": "GET",

--- a/postman/embabel-demo.postman_collection.json
+++ b/postman/embabel-demo.postman_collection.json
@@ -1,13 +1,13 @@
 {
 	"info": {
-		"_postman_id": "088e49e1-a3e9-40a5-9bf6-c13309d96908",
+		"_postman_id": "eb790abb-d83c-4a62-94cd-b1a8fcd2174f",
 		"name": "embabel-demo",
 		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json",
 		"_exporter_id": "3409676"
 	},
 	"item": [
 		{
-			"name": "Dad Joke Generator",
+			"name": "Dad Joke",
 			"request": {
 				"method": "GET",
 				"header": [],
@@ -32,7 +32,7 @@
 			"response": []
 		},
 		{
-			"name": "Story Writer",
+			"name": "Story",
 			"request": {
 				"method": "GET",
 				"header": [],
@@ -57,7 +57,35 @@
 			"response": []
 		},
 		{
-			"name": "Compute Fibonacci",
+			"name": "Story",
+			"request": {
+				"method": "POST",
+				"header": [],
+				"body": {
+					"mode": "raw",
+					"raw": "# Chat: P1 INC0042069 - KangarooBank Mobile App displaying negative balances as positive\n---\n\n## Chat Members\n- Bazza\n- Brenda\n- Callum\n- Damo\n- Fiona\n- Gavin\n- Hayley\n- Jono\n- Karen\n- Lachlan (known as Lachy)\n- Megan (known as Megs)\n- Neville\n- Priya\n- Rhonda\n- Shane\n- Tanya\n- Wayne\n\n## Chat Content\nTuesday 6 May 2026 9:03AM AEST\n\nHi Team,\n\nRaising a P1. KangarooBank Mobile App is showing negative balances as positive numbers for all customers. We have customers celebrating paying off their mortgage when they actually owe $450,000. Social media is going nuts.\n\nCallum Reid (AU) changed the group name to P1 INC0042069 - KangarooBank Mobile Negative Balance Display.\n\nTuesday 6 May 2026 9:06AM AEST\n\nMorning all. We are looking into it now.\n\nDamo Fitzpatrick (AU) added Priya Sharma (AU) and Lachlan O'Brien (AU) to the chat and shared all chat history.\n\nTuesday 6 May 2026 9:08AM AEST\n\nJust to confirm the scope - this is ALL customers or just a subset?\n\nTuesday 6 May 2026 9:10AM AEST\n\nAll of them Priya. Every single one. My mum just rang me to say she's going to Bali because her credit card is showing she's $12,000 in the black.\n\nTuesday 6 May 2026 9:11AM AEST\n\nPlease tell your mum not to book anything yet\n\nToo late. She's already at the airport.\n\nCallum Reid (AU)\nBrilliant. Ok, which release went out last night?\n\nTuesday 6 May 2026 9:14AM AEST\n\nv4.7.2 went to prod at 11:45PM AEST last night. It was the currency formatting update for the new multi-currency feature.\n\nTuesday 6 May 2026 9:21AM AEST\n\nFound it. Someone changed `Math.abs()` on the balance display thinking it was fixing a formatting bug. It's literally taking the absolute value of every balance. Every negative number is now positive.\n\nDamo Fitzpatrick (AU)\nFound it. Someone changed `Math.abs()` on the balance display thinking it was fixing a formatting bug.\nYou're joking. Who approved that PR?\n\nWayne Bucket (AU) added Gavin Thornton (AU) to the chat and shared all chat history.\n\nTuesday 6 May 2026 9:23AM AEST\n\nGavin Thornton (AU) - FYI you approved the PR for the currency formatting change. Can you jump on this please.\n\nTuesday 6 May 2026 9:25AM AEST\n\nLook I saw \"fix negative display issue\" in the PR title and the tests were green. How was I supposed to know they meant they were REMOVING the negative sign, not fixing a rendering bug?\n\nTuesday 6 May 2026 9:26AM AEST\n\nThe unit test literally says `assertEquals(450000, formatBalance(-450000))` and you thought that was CORRECT?\n\nTuesday 6 May 2026 9:27AM AEST\n\nIn my defence it was 4:30 on a Friday\n\nTanya Wells (AU) added Karen Mitchell (AU) to the chat and shared all chat history.\n\nTuesday 6 May 2026 9:29AM AEST\n\nKaren Mitchell (AU) - Comms are asking how many customers are affected. The ABC has picked it up.\n\nFiona Xu (AU)\nKaren Mitchell (AU) - Comms are asking how many customers are affected. The ABC has picked it up.\n2.3 million active mobile app users. All of them are seeing incorrect balances.\n\nTuesday 6 May 2026 9:31AM AEST\n\nOh good lord. What's the hashtag?\n\nTuesday 6 May 2026 9:32AM AEST\n\n#KangarooBank is trending. Also #FreeMoney and #ThankYouKangaroo. Someone's made a TikTok already with 400k views.\n\nBrenda Hooper (AU) added Shane Gallagher (AU) and Rhonda Park (AU) to the chat and shared all chat history.\n\nTuesday 6 May 2026 9:34AM AEST\n\nShane Gallagher (AU) / Rhonda Park (AU) - Contact centre update: call volumes up 3,400%. Queue time is 4 hours. Customers are calling to confirm they've paid off their home loan. One bloke in Toowoomba is at a Porsche dealership trying to get finance approved based on his app screenshot.\n\nShane Gallagher (AU)\nOne bloke in Toowoomba is at a Porsche dealership trying to get finance approved based on his app screenshot.\nCan we please focus on the fix. Damo how long to rollback?\n\nTuesday 6 May 2026 9:37AM AEST\n\nRollback is ready. Deploying v4.7.1 now. ETA 15 minutes.\n\nTuesday 6 May 2026 9:38AM AEST\n\nCan we put a banner on the app in the meantime? Something like \"Balances may be temporarily incorrect\"\n\nNeville Bruce (AU)\nCan we put a banner on the app in the meantime?\nAlready on it. Legal is reviewing the wording now.\n\nTuesday 6 May 2026 9:41AM AEST\n\nLegal came back. They don't want us to say \"incorrect\". They want us to say \"balances are currently undergoing a scheduled display refresh\"\n\nTuesday 6 May 2026 9:42AM AEST\n\nA SCHEDULED DISPLAY REFRESH? We turned everyone's debt into savings and we're calling it a SCHEDULED DISPLAY REFRESH?\n\nMegan Porter (AU)\nA SCHEDULED DISPLAY REFRESH?\nI don't write the copy Karen, I just pass it along.\n\nTuesday 6 May 2026 9:51AM AEST\n\nRollback deployed. Balances should be correcting now. Can everyone check?\n\nTuesday 6 May 2026 9:53AM AEST\n\nConfirmed. My test account is showing -$2,450.00 again as expected.\n\nPriya Sharma (AU)\nConfirmed. My test account is showing -$2,450.00 again as expected.\nSame here. Negative balances are back to negative.\n\nTuesday 6 May 2026 9:55AM AEST\n\nTwitter is now full of people saying we've stolen their money because their balance \"went down\". We can't win.\n\nJono Mackenzie (AU) added Hayley Chen (AU) to the chat and shared all chat history.\n\nTuesday 6 May 2026 9:58AM AEST\n\nHayley Chen (AU) - Compliance here. APRA are on the phone. They want to know how a `Math.abs()` call made it through our change management process.\n\nTuesday 6 May 2026 9:59AM AEST\n\nTell APRA our change management process is very thorough and this was an isolated incident\n\nTuesday 6 May 2026 10:00AM AEST\n\nGavin it literally passed through your review with a comment that said \"looks good mate, chuck it in\" at 4:47PM on a Friday\n\nBazza Wentworth (AU)\nTell APRA our change management process is very thorough\nI just want to flag that three customers have already applied for loans at other banks using screenshots of their KangarooBank \"positive\" balances as proof of savings. Fraud team is across it.\n\nTuesday 6 May 2026 10:03AM AEST\n\nUpdate from contact centre: A customer in Cairns withdrew $15,000 cash this morning before balances were corrected. She said she \"wanted to get it out before the bank realised their mistake.\" She's now at the airport.\n\nTuesday 6 May 2026 10:05AM AEST\n\nCan we get a timeline for the PIR? APRA want it by COB Friday.\n\nTuesday 6 May 2026 10:06AM AEST\n\nScheduling PIR for Thursday 8 May, 10AM AEST. All team leads please block your calendars.\n\nDamo Fitzpatrick (AU)\nRollback deployed. Balances should be correcting now.\nCan we confirm the fix is fully propagated? CDN cache?\n\nTuesday 6 May 2026 10:08AM AEST\n\nGood call. CDN cache TTL is 30 minutes. Some users might still see old values until 10:15AM AEST.\n\nTuesday 6 May 2026 10:14AM AEST\n\nConfirmed all balances are displaying correctly now. Datadog monitors are green.\n\nTuesday 6 May 2026 10:22AM AEST\n\nFinal count from contact centre: 47,000 calls received. 312 customers attempted transactions based on incorrect balances. 4 car dealership visits. 1 customer put a deposit on a boat in Airlie Beach.\n\nTuesday 6 May 2026 10:25AM AEST\n\nCan we resolve this incident?\n\nTuesday 6 May 2026 10:26AM AEST\n\nYes but I want the following actions logged:\n1. Code review process update - no more Friday afternoon approvals\n2. Unit test review - tests should not pass when they assert that negative numbers equal positive numbers\n3. Balance display changes require sign-off from Finance team\n4. Gavin to complete mandatory code review training\n\nGavin Thornton (AU)\nIn my defence it was 4:30 on a Friday\nNoted, Callum. I will also be updating my LinkedIn to \"Available for new opportunities.\"\n\nTuesday 6 May 2026 10:28AM AEST\n\nLet's not be hasty Gavin. But maybe no more Friday deploys yeah?\n\nShane Gallagher (AU)\n1 customer put a deposit on a boat in Airlie Beach.\nCan someone please follow up on the boat situation? Legal wants to know if we're liable.\n\nTuesday 6 May 2026 10:31AM AEST\n\nResolving INC0042069. PIR scheduled for Thursday 8 May. All action items logged.\n\nTuesday 6 May 2026 10:33AM AEST\n\nThanks everyone. Great work getting this sorted quickly. And Gavin - we've all been there mate.\n\nTuesday 6 May 2026 10:34AM AEST\n\nNot like this we haven't.\n",
+					"options": {
+						"raw": {
+							"language": "json"
+						}
+					}
+				},
+				"url": {
+					"raw": "http://localhost:8080/story",
+					"protocol": "http",
+					"host": [
+						"localhost"
+					],
+					"port": "8080",
+					"path": [
+						"story"
+					]
+				}
+			},
+			"response": []
+		},
+		{
+			"name": "Fibonacci",
 			"request": {
 				"method": "GET",
 				"header": [],

--- a/src/main/java/com/embabel/demo/agent/StoryAgent.java
+++ b/src/main/java/com/embabel/demo/agent/StoryAgent.java
@@ -41,21 +41,21 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Profile;
 
 /**
- * Based on WriteAndReviewAgent in
+ * Based on StoryAgent in
  * <a href="https://github.com/embabel/java-agent-template/blob/main/src/main/java/com/embabel/template/agent/WriteAndReviewAgent.java">java-agent-template</a>.
  */
 @Agent(description = "Generate stories based on user input, review them, and return the best one")
 @Profile("!test")
-public class WriteAndReviewAgent {
+public class StoryAgent {
 
-    private static final Logger LOG = LoggerFactory.getLogger(WriteAndReviewAgent.class);
+    private static final Logger LOG = LoggerFactory.getLogger(StoryAgent.class);
     private static final int MAX_RETRIES = 3;
 
     private final int storyCount;
     private final int storyWordCount;
     private final int reviewWordCount;
 
-    public WriteAndReviewAgent(
+    public StoryAgent(
             @Value("${storyCount:3}") int storyCount,
             @Value("${storyWordCount:500}") int storyWordCount,
             @Value("${reviewWordCount:100}") int reviewWordCount
@@ -118,7 +118,7 @@ public class WriteAndReviewAgent {
 
     @AchievesGoal(
             description = "Stories have been crafted, reviewed, and the best one selected",
-            export = @Export(remote = true, name = "writeAndReviewStory", startingInputTypes = {UserInput.class}))
+            export = @Export(remote = true, name = "story", startingInputTypes = {UserInput.class}))
     @Action
     public ReviewedStory selectBestStory(ReviewedStories reviewedStories) {
         return reviewedStories.reviewedStories().stream()

--- a/src/main/java/com/embabel/demo/agent/StoryAgent.java
+++ b/src/main/java/com/embabel/demo/agent/StoryAgent.java
@@ -120,9 +120,10 @@ public class StoryAgent {
             description = "Stories have been crafted, reviewed, and the best one selected",
             export = @Export(remote = true, name = "story", startingInputTypes = {UserInput.class}))
     @Action
-    public ReviewedStory selectBestStory(ReviewedStories reviewedStories) {
+    public Story selectBestStory(ReviewedStories reviewedStories) {
         return reviewedStories.reviewedStories().stream()
                 .max(Comparator.comparingInt(rs -> rs.review().rating()))
+                .map(ReviewedStory::story)
                 .orElseThrow();
     }
 }

--- a/src/main/java/com/embabel/demo/controller/StoryController.java
+++ b/src/main/java/com/embabel/demo/controller/StoryController.java
@@ -21,7 +21,7 @@ import org.springframework.web.bind.annotation.RestController;
  * <a href="http://localhost:8080/story?about=Steven">http://localhost:8080/story?about=Steven</a>
  */
 @RestController
-public record StoryWriterController(AgentPlatform agentPlatform) {
+public record StoryController(AgentPlatform agentPlatform) {
 
     @GetMapping(value = "/story", produces = MediaType.TEXT_PLAIN_VALUE)
     public String writeAStory(@RequestParam("about") String about) {

--- a/src/main/java/com/embabel/demo/controller/StoryWriterController.java
+++ b/src/main/java/com/embabel/demo/controller/StoryWriterController.java
@@ -17,18 +17,18 @@ import org.springframework.web.bind.annotation.RestController;
  * 1. Comment out "embabel-agent-starter-shell" in pom.xml to disable the shell.
  * 2. Run the application.
  * 3. Open a browser and go to:
- * <a href="http://localhost:8080/write-a-story?about=Steven">http://localhost:8080/write-a-story?about=Steven</a>
+ * <a href="http://localhost:8080/story?about=Steven">http://localhost:8080/story?about=Steven</a>
  */
 @RestController
 public record StoryWriterController(AgentPlatform agentPlatform) {
 
-    @GetMapping("/write-a-story")
+    @GetMapping("/story")
     public ReviewedStory writeAStory(@RequestParam("about") String about) {
         return AgentInvocation.create(agentPlatform, ReviewedStory.class)
                 .invoke(new UserInput("Write a story about %s".formatted(about)));
     }
 
-    @PostMapping("/write-a-story")
+    @PostMapping("/story")
     public ReviewedStory writeAStoryFromPost(@RequestBody String about) {
         return AgentInvocation.create(agentPlatform, ReviewedStory.class)
                 .invoke(new UserInput(about));

--- a/src/main/java/com/embabel/demo/controller/StoryWriterController.java
+++ b/src/main/java/com/embabel/demo/controller/StoryWriterController.java
@@ -3,7 +3,8 @@ package com.embabel.demo.controller;
 import com.embabel.agent.api.invocation.AgentInvocation;
 import com.embabel.agent.core.AgentPlatform;
 import com.embabel.agent.domain.io.UserInput;
-import com.embabel.demo.model.story.ReviewedStory;
+import com.embabel.demo.model.story.Story;
+import org.springframework.http.MediaType;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -22,15 +23,17 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 public record StoryWriterController(AgentPlatform agentPlatform) {
 
-    @GetMapping("/story")
-    public ReviewedStory writeAStory(@RequestParam("about") String about) {
-        return AgentInvocation.create(agentPlatform, ReviewedStory.class)
-                .invoke(new UserInput("Write a story about %s".formatted(about)));
+    @GetMapping(value = "/story", produces = MediaType.TEXT_PLAIN_VALUE)
+    public String writeAStory(@RequestParam("about") String about) {
+        return AgentInvocation.create(agentPlatform, Story.class)
+                .invoke(new UserInput("Write a story about %s".formatted(about)))
+                .text();
     }
 
-    @PostMapping("/story")
-    public ReviewedStory writeAStoryFromPost(@RequestBody String about) {
-        return AgentInvocation.create(agentPlatform, ReviewedStory.class)
-                .invoke(new UserInput(about));
+    @PostMapping(value = "/story", produces = MediaType.TEXT_PLAIN_VALUE)
+    public String writeAStoryFromPost(@RequestBody String about) {
+        return AgentInvocation.create(agentPlatform, Story.class)
+                .invoke(new UserInput(about))
+                .text();
     }
 }

--- a/src/main/java/com/embabel/demo/prompt/persona/StoryPersonas.java
+++ b/src/main/java/com/embabel/demo/prompt/persona/StoryPersonas.java
@@ -5,7 +5,7 @@ import com.embabel.agent.prompt.persona.RoleGoalBackstory;
 
 /**
  * Based on Persona in
- * <a href="https://github.com/embabel/java-agent-template/blob/main/src/main/java/com/embabel/template/agent/WriteAndReviewAgent.java">java-agent-template</a>.
+ * <a href="https://github.com/embabel/java-agent-template/blob/main/src/main/java/com/embabel/template/agent/StoryAgent.java">java-agent-template</a>.
  */
 public abstract class StoryPersonas {
     public static final RoleGoalBackstory WRITER = new RoleGoalBackstory(

--- a/src/test/java/com/embabel/demo/agent/StoryAgentIntegrationTest.java
+++ b/src/test/java/com/embabel/demo/agent/StoryAgentIntegrationTest.java
@@ -17,7 +17,7 @@ import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
 
 @SpringBootTest(classes = Application.class)
-class WriteAndReviewAgentIntegrationTest extends EmbabelMockitoIntegrationTest {
+class StoryAgentIntegrationTest extends EmbabelMockitoIntegrationTest {
 
     @BeforeAll
     static void setUp() {

--- a/src/test/java/com/embabel/demo/agent/StoryAgentUnitTest.java
+++ b/src/test/java/com/embabel/demo/agent/StoryAgentUnitTest.java
@@ -12,7 +12,7 @@ import java.time.Instant;
 import java.util.List;
 import org.junit.jupiter.api.Test;
 
-class WriteAndReviewAgentUnitTest {
+class StoryAgentUnitTest {
 
     @Test
     void testCraftStories() {
@@ -21,7 +21,7 @@ class WriteAndReviewAgentUnitTest {
         context.expectResponse(new Story("One upon a time Sir Galahad . . "));
         context.expectResponse(new Story("Sir Galahad rode into the sunset . . "));
 
-        var agent = new WriteAndReviewAgent(2, 200, 400);
+        var agent = new StoryAgent(2, 200, 400);
         agent.craftStories(new UserInput("Tell me a story about a brave knight", Instant.now()), context);
 
         String prompt = promptRunner.getLlmInvocations().getFirst().getMessages().getFirst().getContent();
@@ -30,7 +30,7 @@ class WriteAndReviewAgentUnitTest {
 
     @Test
     void testReviewStories() {
-        var agent = new WriteAndReviewAgent(2, 200, 400);
+        var agent = new StoryAgent(2, 200, 400);
         var userInput = new UserInput("Tell me a story about a brave knight", Instant.now());
         var stories = new Stories(List.of(new Story("Once upon a time, Sir Galahad...")));
         var context = FakeOperationContext.create();

--- a/src/test/java/com/embabel/demo/controller/RestControllerIntegrationTest.java
+++ b/src/test/java/com/embabel/demo/controller/RestControllerIntegrationTest.java
@@ -92,8 +92,8 @@ class RestControllerIntegrationTest {
 
     @Test
     void shouldWriteAStory() throws Exception {
-        LOG.info("Calling GET /write-a-story?about=a+brave+robot ...");
-        var json = getJson(BASE_URL + "/write-a-story?about=a+brave+robot");
+        LOG.info("Calling GET /story?about=a+brave+robot ...");
+        var json = getJson(BASE_URL + "/story?about=a+brave+robot");
 
         LOG.debug("Response:\n\n{}\n\n", json);
 
@@ -120,8 +120,8 @@ class RestControllerIntegrationTest {
     @Test
     void shouldWriteAStoryFromPost() throws Exception {
         var story = Files.readString(Path.of("src/test/resources/Incident Chat.md"), StandardCharsets.UTF_8);
-        LOG.info("Calling POST /write-a-story with {} chars ...", story.length());
-        var json = postTextForJson(BASE_URL + "/write-a-story", story);
+        LOG.info("Calling POST /story with {} chars ...", story.length());
+        var json = postTextForJson(BASE_URL + "/story", story);
 
         LOG.debug("Response:\n\n{}\n\n", json);
 

--- a/src/test/java/com/embabel/demo/mcp/McpServerIntegrationTest.java
+++ b/src/test/java/com/embabel/demo/mcp/McpServerIntegrationTest.java
@@ -157,7 +157,7 @@ class McpServerIntegrationTest {
 
         assertThat(toolNames)
                 .as("Expected MCP tools from exported agents")
-                .contains("dadJoke", "fibonacciNumbers", "writeAndReviewStory");
+                .contains("dadJoke", "fibonacciNumbers", "story");
     }
 
     @Test
@@ -231,10 +231,10 @@ class McpServerIntegrationTest {
 
     @Test
     @Timeout(120)
-    void shouldInvokeWriteAndReviewStoryTool() throws Exception {
-        LOG.info("Invoking tools/call for writeAndReviewStory...");
+    void shouldInvokeStoryTool() throws Exception {
+        LOG.info("Invoking tools/call for story...");
         var params = MAPPER.createObjectNode();
-        params.put("name", "writeAndReviewStory");
+        params.put("name", "story");
         params.set("arguments", MAPPER.createObjectNode().put("content", "a brave developer who fixed a production outage"));
 
         postJsonRpc("tools/call", 80, params);
@@ -242,7 +242,7 @@ class McpServerIntegrationTest {
 
         assertThat(response.has("result")).as("tools/call has result").isTrue();
         var result = response.get("result");
-        LOG.info("writeAndReviewStory result:\n\n{}\n\n", MAPPER.writeValueAsString(result));
+        LOG.info("story result:\n\n{}\n\n", MAPPER.writeValueAsString(result));
 
         assertThat(result.has("content")).as("result has content").isTrue();
         var content = result.get("content");
@@ -253,7 +253,7 @@ class McpServerIntegrationTest {
         assertThat(firstContent.get("type").asText()).as("content type is text").isEqualTo("text");
 
         var text = firstContent.get("text").asText();
-        LOG.info("writeAndReviewStory response text:\n\n{}\n\n", text);
+        LOG.info("story response text:\n\n{}\n\n", text);
 
         assertThat(text).as("response contains story section").contains("# Story");
         assertThat(text).as("response contains review section").contains("# Review");


### PR DESCRIPTION
## Summary

- Rename `WriteAndReviewAgent` to `StoryAgent` across all Java files, tests, docs, and Postman collection
- Rename `/write-a-story` endpoint to `/story`
- Change MCP export name from `writeAndReviewStory` to `story`
- Simplify `/story` endpoint to return plain text (story only) instead of JSON with review data

## Test plan

- [x] Unit tests pass (`StoryAgentUnitTest`)
- [x] Compilation succeeds
- [ ] Run integration tests against a live instance
- [ ] Verify MCP tool name `story` works via Claude Code
- [ ] Verify `/story?about=...` returns plain text

🤖 Generated with [Claude Code](https://claude.com/claude-code)