### PR TITLE
Tag git repo when pushing to Docker Hub

### DIFF
--- a/docker-push.sh
+++ b/docker-push.sh
@@ -16,4 +16,8 @@ docker push "${VERSIONED_TAG}"
 echo "Pushing ${LATEST_TAG}..."
 docker push "${LATEST_TAG}"
 
+echo "Tagging git repo with ${TAG}..."
+git tag "${TAG}"
+git push origin "${TAG}"
+
 echo "Done. Image available at https://hub.docker.com/r/${DOCKER_USER}/${IMAGE_NAME}"


### PR DESCRIPTION
## Summary
- Adds a git tag matching the Docker image version tag (e.g. `20260412-143052`) after pushing to Docker Hub
- Pushes the tag to origin so the repo commit is linked to the published image

## Test plan
- [ ] Run `docker-push.sh` and verify the git tag is created locally
- [ ] Verify the tag is pushed to the remote repository
- [ ] Confirm the tag matches the Docker image tag

🤖 Generated with [Claude Code](https://claude.com/claude-code)