### PR TITLE
Add Spring Security with role-based PreAuthorize on controllers

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -77,6 +77,12 @@
             <artifactId>spring-boot-starter-web</artifactId>
         </dependency>
 
+        <!-- https://mvnrepository.com/artifact/org.springframework.boot/spring-boot-starter-security -->
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-security</artifactId>
+        </dependency>
+
         <!-- https://mvnrepository.com/artifact/org.springframework.shell/spring-shell-standard -->
         <dependency>
             <groupId>org.springframework.shell</groupId>
@@ -88,6 +94,13 @@
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <!-- https://mvnrepository.com/artifact/org.springframework.security/spring-security-test -->
+        <dependency>
+            <groupId>org.springframework.security</groupId>
+            <artifactId>spring-security-test</artifactId>
             <scope>test</scope>
         </dependency>
 

--- a/src/main/java/com/embabel/demo/config/SecurityConfig.java
+++ b/src/main/java/com/embabel/demo/config/SecurityConfig.java
@@ -1,0 +1,41 @@
+package com.embabel.demo.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.core.userdetails.User;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.provisioning.InMemoryUserDetailsManager;
+import org.springframework.security.web.SecurityFilterChain;
+
+import static org.springframework.security.config.Customizer.withDefaults;
+
+@Configuration
+@EnableMethodSecurity
+public class SecurityConfig {
+
+    @Bean
+    public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+        return http
+                .authorizeHttpRequests(auth -> auth.anyRequest().authenticated())
+                .httpBasic(withDefaults())
+                .csrf(csrf -> csrf.disable())
+                .build();
+    }
+
+    @Bean
+    public UserDetailsService userDetailsService() {
+        var user = User.withDefaultPasswordEncoder()
+                .username("user")
+                .password("password")
+                .roles("USER")
+                .build();
+        var dad = User.withDefaultPasswordEncoder()
+                .username("dad")
+                .password("password")
+                .roles("DAD", "USER")
+                .build();
+        return new InMemoryUserDetailsManager(user, dad);
+    }
+}

--- a/src/main/java/com/embabel/demo/controller/DadJokeController.java
+++ b/src/main/java/com/embabel/demo/controller/DadJokeController.java
@@ -4,6 +4,7 @@ import com.embabel.agent.api.invocation.AgentInvocation;
 import com.embabel.agent.core.AgentPlatform;
 import com.embabel.agent.domain.io.UserInput;
 import com.embabel.demo.model.dadjoke.DadJokeResult;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
@@ -18,8 +19,15 @@ import org.springframework.web.bind.annotation.RestController;
  * <a href="http://localhost:8080/best-dad-joke?topic=chicken">http://localhost:8080/best-dad-joke?topic=chicken</a>
  */
 @RestController
-public record DadJokeController(AgentPlatform agentPlatform) {
+public class DadJokeController {
 
+    private final AgentPlatform agentPlatform;
+
+    public DadJokeController(AgentPlatform agentPlatform) {
+        this.agentPlatform = agentPlatform;
+    }
+
+    @PreAuthorize("hasRole('DAD')")
     @GetMapping("/dad-joke")
     public DadJokeResult getDadJoke(@RequestParam("topic") String topic) {
         return AgentInvocation.create(agentPlatform, DadJokeResult.class)

--- a/src/main/java/com/embabel/demo/controller/FibonacciController.java
+++ b/src/main/java/com/embabel/demo/controller/FibonacciController.java
@@ -4,12 +4,19 @@ import com.embabel.agent.api.invocation.AgentInvocation;
 import com.embabel.agent.core.AgentPlatform;
 import com.embabel.demo.model.fibonacci.FibonacciRequest;
 import com.embabel.demo.model.fibonacci.FibonacciResponseWithVerification;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
-public record FibonacciController(AgentPlatform agentPlatform) {
+public class FibonacciController {
+
+    private final AgentPlatform agentPlatform;
+
+    public FibonacciController(AgentPlatform agentPlatform) {
+        this.agentPlatform = agentPlatform;
+    }
 
     /**
      * Compute Fibonacci number with verification.
@@ -17,10 +24,10 @@ public record FibonacciController(AgentPlatform agentPlatform) {
      * @param iterations The number of iterations. Must be non-negative. Starts from 0.
      * @return FibonacciResponseWithVerification containing the fibonacciNumber and verification status
      */
+    @PreAuthorize("hasRole('USER')")
     @GetMapping("/compute-fibonacci")
     public FibonacciResponseWithVerification computeFibonacci(@RequestParam("iterations") int iterations) {
         return AgentInvocation.create(agentPlatform, FibonacciResponseWithVerification.class)
                 .invoke(new FibonacciRequest(iterations));
     }
-
 }

--- a/src/main/java/com/embabel/demo/controller/SonicPiController.java
+++ b/src/main/java/com/embabel/demo/controller/SonicPiController.java
@@ -11,6 +11,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -29,6 +30,7 @@ public class SonicPiController {
         this.agentPlatform = agentPlatform;
     }
 
+    @PreAuthorize("hasRole('USER')")
     @PostMapping("/sonic-pi")
     public ResponseEntity<Map<String, String>> generateSonicPi(@RequestParam("prompt") String prompt) {
         String jobId = UUID.randomUUID().toString();
@@ -51,6 +53,7 @@ public class SonicPiController {
                 .body(Map.of("jobId", jobId));
     }
 
+    @PreAuthorize("hasRole('USER')")
     @GetMapping("/sonic-pi/{jobId}")
     public ResponseEntity<SonicPiJob> getJobStatus(@PathVariable String jobId) {
         SonicPiJob job = jobs.get(jobId);

--- a/src/main/java/com/embabel/demo/controller/StoryController.java
+++ b/src/main/java/com/embabel/demo/controller/StoryController.java
@@ -5,6 +5,7 @@ import com.embabel.agent.core.AgentPlatform;
 import com.embabel.agent.domain.io.UserInput;
 import com.embabel.demo.model.story.Story;
 import org.springframework.http.MediaType;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -21,8 +22,15 @@ import org.springframework.web.bind.annotation.RestController;
  * <a href="http://localhost:8080/story?about=Steven">http://localhost:8080/story?about=Steven</a>
  */
 @RestController
-public record StoryController(AgentPlatform agentPlatform) {
+public class StoryController {
 
+    private final AgentPlatform agentPlatform;
+
+    public StoryController(AgentPlatform agentPlatform) {
+        this.agentPlatform = agentPlatform;
+    }
+
+    @PreAuthorize("hasRole('USER')")
     @GetMapping(value = "/story", produces = MediaType.TEXT_PLAIN_VALUE)
     public String writeAStory(@RequestParam("about") String about) {
         return AgentInvocation.create(agentPlatform, Story.class)
@@ -30,6 +38,7 @@ public record StoryController(AgentPlatform agentPlatform) {
                 .text();
     }
 
+    @PreAuthorize("hasRole('USER')")
     @PostMapping(value = "/story", produces = MediaType.TEXT_PLAIN_VALUE)
     public String writeAStoryFromPost(@RequestBody String about) {
         return AgentInvocation.create(agentPlatform, Story.class)


### PR DESCRIPTION
## Summary
- Added `spring-boot-starter-security` dependency (version managed by Spring Boot parent 3.5.11)
- Created `SecurityConfig` with `@EnableMethodSecurity`, HTTP Basic auth, and two in-memory demo users (`user`/USER role, `dad`/DAD+USER roles)
- Added `@PreAuthorize("hasRole('DAD')")` to `DadJokeController` and `@PreAuthorize("hasRole('USER')")` to all other controllers
- Converted record-based controllers to regular classes for CGLIB proxy compatibility with method security

## Test plan
- [ ] Verify `GET /dad-joke?topic=chicken` returns 403 when authenticated as `user` (USER role only)
- [ ] Verify `GET /dad-joke?topic=chicken` succeeds when authenticated as `dad` (DAD role)
- [ ] Verify `GET /story?about=Steven`, `GET /compute-fibonacci?iterations=5`, and `POST /sonic-pi` succeed with USER role
- [ ] Verify unauthenticated requests return 401

🤖 Generated with [Claude Code](https://claude.com/claude-code)