### PR TITLE
Add shell script to list available LLM models

### DIFF
--- a/list-models.sh
+++ b/list-models.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env sh
+#
+# List available models from an LLM provider API.
+#
+# Usage:
+#   ./list-models.sh                  # default: anthropic
+#   ./list-models.sh openai
+#   ./list-models.sh ollama
+#   ./list-models.sh anthropic
+
+set -e
+
+PROVIDER="${1:-anthropic}"
+
+case "$PROVIDER" in
+  openai)
+    if [ -z "$OPENAI_API_KEY" ]; then
+      echo "ERROR: OPENAI_API_KEY environment variable is not set." >&2
+      exit 1
+    fi
+    if [ -z "$OPENAI_BASE_URL" ]; then
+      echo "ERROR: OPENAI_BASE_URL environment variable is not set." >&2
+      exit 1
+    fi
+    MODELS_URL="${OPENAI_BASE_URL}/models?api-version=2024-10-21"
+    echo "Fetching models from ${MODELS_URL}..."
+    curl -sS "$MODELS_URL" -H "api-key: ${OPENAI_API_KEY}" \
+      | jq -r '.data[].id' | sort
+    ;;
+
+  anthropic)
+    if [ -z "$ANTHROPIC_API_KEY" ]; then
+      echo "ERROR: ANTHROPIC_API_KEY environment variable is not set." >&2
+      exit 1
+    fi
+    BASE_URL="${ANTHROPIC_BASE_URL:-https://litellm.fcm.digital}"
+    MODELS_URL="${BASE_URL}/v1/models"
+    echo "Fetching models from ${MODELS_URL}..."
+    curl -sS "$MODELS_URL" -H "Authorization: Bearer ${ANTHROPIC_API_KEY}" \
+      | jq -r '.data[].id' | sort
+    ;;
+
+  ollama)
+    MODELS_URL="http://localhost:11434/api/tags"
+    echo "Fetching models from ${MODELS_URL}..."
+    curl -sS "$MODELS_URL" | jq -r '.models[].name' | sort
+    ;;
+
+  *)
+    echo "ERROR: Unknown provider '${PROVIDER}'. Valid values: openai, ollama, anthropic" >&2
+    exit 1
+    ;;
+esac

--- a/list-models.sh
+++ b/list-models.sh
@@ -18,13 +18,10 @@ case "$PROVIDER" in
       echo "ERROR: OPENAI_API_KEY environment variable is not set." >&2
       exit 1
     fi
-    if [ -z "$OPENAI_BASE_URL" ]; then
-      echo "ERROR: OPENAI_BASE_URL environment variable is not set." >&2
-      exit 1
-    fi
-    MODELS_URL="${OPENAI_BASE_URL}/models?api-version=2024-10-21"
+    BASE_URL="${OPENAI_BASE_URL:-https://api.openai.com/v1}"
+    MODELS_URL="${BASE_URL}/models"
     echo "Fetching models from ${MODELS_URL}..."
-    curl -sS "$MODELS_URL" -H "api-key: ${OPENAI_API_KEY}" \
+    curl -sS "$MODELS_URL" -H "Authorization: Bearer ${OPENAI_API_KEY}" \
       | jq -r '.data[].id' | sort
     ;;
 
@@ -33,11 +30,7 @@ case "$PROVIDER" in
       echo "ERROR: ANTHROPIC_API_KEY environment variable is not set." >&2
       exit 1
     fi
-    if [ -z "$ANTHROPIC_BASE_URL" ]; then
-      echo "ERROR: ANTHROPIC_BASE_URL environment variable is not set." >&2
-      exit 1
-    fi
-    BASE_URL="$ANTHROPIC_BASE_URL"
+    BASE_URL="${ANTHROPIC_BASE_URL:-https://api.anthropic.com}"
     MODELS_URL="${BASE_URL}/v1/models"
     echo "Fetching models from ${MODELS_URL}..."
     curl -sS "$MODELS_URL" -H "Authorization: Bearer ${ANTHROPIC_API_KEY}" \

--- a/list-models.sh
+++ b/list-models.sh
@@ -13,18 +13,6 @@ set -e
 PROVIDER="${1:-anthropic}"
 
 case "$PROVIDER" in
-  openai)
-    if [ -z "$OPENAI_API_KEY" ]; then
-      echo "ERROR: OPENAI_API_KEY environment variable is not set." >&2
-      exit 1
-    fi
-    BASE_URL="${OPENAI_BASE_URL:-https://api.openai.com/v1}"
-    MODELS_URL="${BASE_URL}/models"
-    echo "Fetching models from ${MODELS_URL}..."
-    curl -sS "$MODELS_URL" -H "Authorization: Bearer ${OPENAI_API_KEY}" \
-      | jq -r '.data[].id' | sort
-    ;;
-
   anthropic)
     if [ -z "$ANTHROPIC_API_KEY" ]; then
       echo "ERROR: ANTHROPIC_API_KEY environment variable is not set." >&2
@@ -34,6 +22,18 @@ case "$PROVIDER" in
     MODELS_URL="${BASE_URL}/v1/models"
     echo "Fetching models from ${MODELS_URL}..."
     curl -sS "$MODELS_URL" -H "Authorization: Bearer ${ANTHROPIC_API_KEY}" \
+      | jq -r '.data[].id' | sort
+    ;;
+
+  openai)
+    if [ -z "$OPENAI_API_KEY" ]; then
+      echo "ERROR: OPENAI_API_KEY environment variable is not set." >&2
+      exit 1
+    fi
+    BASE_URL="${OPENAI_BASE_URL:-https://api.openai.com/v1}"
+    MODELS_URL="${BASE_URL}/models"
+    echo "Fetching models from ${MODELS_URL}..."
+    curl -sS "$MODELS_URL" -H "Authorization: Bearer ${OPENAI_API_KEY}" \
       | jq -r '.data[].id' | sort
     ;;
 

--- a/list-models.sh
+++ b/list-models.sh
@@ -33,7 +33,11 @@ case "$PROVIDER" in
       echo "ERROR: ANTHROPIC_API_KEY environment variable is not set." >&2
       exit 1
     fi
-    BASE_URL="${ANTHROPIC_BASE_URL:-https://litellm.fcm.digital}"
+    if [ -z "$ANTHROPIC_BASE_URL" ]; then
+      echo "ERROR: ANTHROPIC_BASE_URL environment variable is not set." >&2
+      exit 1
+    fi
+    BASE_URL="$ANTHROPIC_BASE_URL"
     MODELS_URL="${BASE_URL}/v1/models"
     echo "Fetching models from ${MODELS_URL}..."
     curl -sS "$MODELS_URL" -H "Authorization: Bearer ${ANTHROPIC_API_KEY}" \


### PR DESCRIPTION
## Summary
- Adds `list-models.sh` that queries LLM provider APIs to list available models
- Supports anthropic (default), openai, and ollama providers
- Defaults to public API URLs (`api.anthropic.com`, `api.openai.com`) when base URL env vars are not set

## Test plan
- [x] Run `./list-models.sh` with `ANTHROPIC_API_KEY` set
- [x] Run `./list-models.sh openai` with `OPENAI_API_KEY` set
- [x] Run `./list-models.sh ollama` with Ollama running locally
- [x] Verify error messages when required env vars are missing

🤖 Generated with [Claude Code](https://claude.com/claude-code)