### PR TITLE
Rewrite README and add Getting Started guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,13 +12,13 @@ This demo project showcases four agents that demonstrate what Embabel can do:
 ### Quick taste
 
 ```bash
-curl "http://localhost:8080/dad-joke?topic=cats"
+curl "http://localhost:8080/dad-joke?topic=programming"
 ```
 
 ```json
 {
-  "joke": "Why don't cats play poker? Too many cheetahs!",
-  "rating": 8
+  "joke": "Why do programmers prefer dark mode? Because light attracts bugs!",
+  "rating": 9
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -1,22 +1,39 @@
-> # Security Warning!
-> **This is a Demo project that is publicly available on GitHub!!**
->
-> **Public Location: https://github.com/stevendoolan/embabel-demo**
->
-> We use this project to provide the Embabel Engineers with a working example of an Embabel agent when we need help.
-> This project is not secure, and should not be used in production. It is provided for educational purposes only.
+# Embabel Demo
 
-# About this project
-This project is based on the Embabel Java Agent Template, which is available on GitHub.
-Please keep this project up to date as java-agent-template is updated.
+Build AI agents on the JVM in minutes with [Embabel](https://github.com/embabel/embabel-agent).
 
-https://github.com/embabel/java-agent-template
+This demo project showcases four agents that demonstrate what Embabel can do:
 
-## Documentation
+- **Dad Joke Agent** — generates, rates, and picks the best dad joke
+- **Fibonacci Agent** — computes Fibonacci numbers with LLM + tool verification
+- **Sonic Pi Agent** — turns natural language into music code
+- **Story Agent** — crafts multiple stories, reviews them, and selects the best
 
-- [Setup](docs/setup.md) - Prerequisites, model providers, proxy configuration, and how to build and run
-- [Docker](docs/docker.md) - Pulling from Docker Hub and MCP server via Docker
-- [Docker Push](docs/docker-push.md) - Pushing images to Docker Hub
-- [Docker Compose](docs/docker-compose.md) - Building locally with Docker Compose and MCP server setup
-- [Agent Documentation](docs/agents/index.md) - Detailed documentation for each agent
-- [Updates](docs/updates.md) - Project changelog
+### Quick taste
+
+```bash
+curl "http://localhost:8080/dad-joke?topic=cats"
+```
+
+```json
+{
+  "joke": "Why don't cats play poker? Too many cheetahs!",
+  "rating": 8
+}
+```
+
+**[Get Started](getting-started.md)** — clone, build, and run your first agent in under 5 minutes.
+
+### Learn more
+
+- [Agent Documentation](docs/agents/index.md) — how each agent works
+- [Setup Guide](docs/setup.md) — model providers, proxy config, Maven profiles
+- [Docker](docs/docker.md) — pull from Docker Hub or run as an MCP server
+- [Docker Compose](docs/docker-compose.md) — build and run locally with Compose
+- [Updates](docs/updates.md) — project changelog
+
+---
+
+> **Note:** This is a demo project for educational purposes — not for production use.
+
+Based on [embabel/java-agent-template](https://github.com/embabel/java-agent-template).

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ This demo project showcases four agents that demonstrate what Embabel can do:
 ### Quick taste
 
 ```bash
-curl "http://localhost:8080/dad-joke?topic=programming"
+curl "http://localhost:48080/dad-joke?topic=programming"
 ```
 
 ```json

--- a/getting-started.md
+++ b/getting-started.md
@@ -1,0 +1,88 @@
+[Back to README](README.md)
+
+---
+
+# Getting Started
+
+Get from zero to running AI agents in under 5 minutes.
+
+## Prerequisites
+
+- **Java 21+** — [Download](https://www.azul.com/downloads/#zulu)
+- **Maven 3.9+** — [Download](https://maven.apache.org/download.cgi)
+- **Git**
+- **An API key** — from [OpenAI](https://platform.openai.com/api-keys) or [Anthropic](https://console.anthropic.com/settings/keys)
+
+## Clone and configure
+
+```bash
+git clone https://github.com/stevendoolan/embabel-demo.git
+cd embabel-demo
+```
+
+Set your API key (pick one):
+
+```bash
+# OpenAI
+export OPENAI_API_KEY=<your-key>
+
+# Anthropic
+export ANTHROPIC_API_KEY=<your-key>
+```
+
+## Build and run
+
+```bash
+mvn spring-boot:run
+```
+
+The service starts on `http://localhost:8080`. Once you see `Started DemoApplication`, you're ready.
+
+## Try each agent
+
+### Dad Joke Agent
+
+Generates several dad jokes, rates them, and returns the best one.
+
+```bash
+curl "http://localhost:8080/dad-joke?topic=cats"
+```
+
+### Fibonacci Agent
+
+Uses an LLM to compute a Fibonacci number, then verifies the result with a tool call.
+
+```bash
+curl "http://localhost:8080/compute-fibonacci?iterations=10"
+```
+
+### Story Agent
+
+Writes multiple stories, reviews them, and selects the best one.
+
+```bash
+curl "http://localhost:8080/story?about=a+brave+robot"
+```
+
+### Sonic Pi Agent
+
+Generates Sonic Pi music code from a natural language prompt. This is an async endpoint — submit the job, then poll for the result.
+
+```bash
+# Submit the job
+curl -X POST "http://localhost:8080/sonic-pi?prompt=play+a+happy+melody"
+# Returns: {"jobId": "<id>"}
+
+# Check the result
+curl "http://localhost:8080/sonic-pi/<id>"
+```
+
+## Next steps
+
+- [Agent Documentation](docs/agents/index.md) — detailed docs for each agent, including action flows and configuration
+- [Docker](docs/docker.md) — run from Docker Hub or as an MCP server
+- [Setup Guide](docs/setup.md) — alternative model providers (Ollama, private endpoints), proxy configuration, Maven profiles
+
+---
+
+[Back to README](README.md)

--- a/getting-started.md
+++ b/getting-started.md
@@ -36,7 +36,7 @@ export ANTHROPIC_API_KEY=<your-key>
 mvn spring-boot:run
 ```
 
-The service starts on `http://localhost:8080`. Once you see `Started DemoApplication`, you're ready.
+The service starts on `http://localhost:48080`. Once you see `Started DemoApplication`, you're ready.
 
 ## Try each agent
 
@@ -45,7 +45,7 @@ The service starts on `http://localhost:8080`. Once you see `Started DemoApplica
 Generates several dad jokes, rates them, and returns the best one.
 
 ```bash
-curl "http://localhost:8080/dad-joke?topic=cats"
+curl "http://localhost:48080/dad-joke?topic=cats"
 ```
 
 ### Fibonacci Agent
@@ -53,7 +53,7 @@ curl "http://localhost:8080/dad-joke?topic=cats"
 Uses an LLM to compute a Fibonacci number, then verifies the result with a tool call.
 
 ```bash
-curl "http://localhost:8080/compute-fibonacci?iterations=10"
+curl "http://localhost:48080/compute-fibonacci?iterations=10"
 ```
 
 ### Story Agent
@@ -61,7 +61,7 @@ curl "http://localhost:8080/compute-fibonacci?iterations=10"
 Writes multiple stories, reviews them, and selects the best one.
 
 ```bash
-curl "http://localhost:8080/story?about=a+brave+robot"
+curl "http://localhost:48080/story?about=a+brave+robot"
 ```
 
 ### Sonic Pi Agent
@@ -70,11 +70,11 @@ Generates Sonic Pi music code from a natural language prompt. This is an async e
 
 ```bash
 # Submit the job
-curl -X POST "http://localhost:8080/sonic-pi?prompt=play+a+happy+melody"
+curl -X POST "http://localhost:48080/sonic-pi?prompt=play+a+happy+melody"
 # Returns: {"jobId": "<id>"}
 
 # Check the result
-curl "http://localhost:8080/sonic-pi/<id>"
+curl "http://localhost:48080/sonic-pi/<id>"
 ```
 
 ## Next steps


### PR DESCRIPTION
## Summary
- Rewrites README.md from a bare setup doc into a concise project overview with agent descriptions and a quick-taste curl example
- Adds a new Getting Started guide (`getting-started.md`) that walks users from clone to running all four agents in under 5 minutes
- Reorganises documentation links for discoverability
- Updates all remaining URLs to use port 48080

## Test plan
- [ ] Verify all links in README.md and getting-started.md resolve correctly
- [ ] Confirm curl examples match actual endpoint paths
- [ ] Review rendered Markdown on GitHub for formatting

🤖 Generated with [Claude Code](https://claude.com/claude-code)