### PR TITLE
Standardise on port 48080 everywhere

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,5 +13,5 @@ FROM azul/zulu-openjdk:21-jre
 WORKDIR /app
 COPY --from=build /app/target/*.jar app.jar
 COPY config ./config
-EXPOSE 8080
+EXPOSE 48080
 ENTRYPOINT ["java", "-jar", "app.jar", "--spring.config.additional-location=file:/app/config/all/"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,7 +4,7 @@ services:
       context: .
       dockerfile: Dockerfile
     ports:
-      - "48080:8080"
+      - "48080:48080"
     environment:
       - ANTHROPIC_BASE_URL=${ANTHROPIC_BASE_URL}
       - ANTHROPIC_API_KEY=${ANTHROPIC_API_KEY}

--- a/docker-run.sh
+++ b/docker-run.sh
@@ -28,7 +28,7 @@ else
 fi
 
 # Build docker run arguments
-ARGS=("-p" "${PORT}:8080" "--name" "${CONTAINER_NAME}")
+ARGS=("-p" "${PORT}:${PORT}" "--name" "${CONTAINER_NAME}")
 
 # Point Ollama at the Docker host so the container can reach it
 ARGS+=("-e" "SPRING_AI_OLLAMA_BASE_URL=http://host.docker.internal:11434")

--- a/docs/docker.md
+++ b/docs/docker.md
@@ -78,7 +78,7 @@ docker pull stevendoolan/embabel-demo:latest
 **All providers (Anthropic + OpenAI):**
 
 ```bash
-docker run -d -p 48080:8080 \
+docker run -d -p 48080:48080 \
   -e ANTHROPIC_BASE_URL \
   -e ANTHROPIC_API_KEY \
   -e OPENAI_BASE_URL \
@@ -90,7 +90,7 @@ docker run -d -p 48080:8080 \
 **Anthropic:**
 
 ```bash
-docker run -d -p 48080:8080 \
+docker run -d -p 48080:48080 \
   -e ANTHROPIC_BASE_URL \
   -e ANTHROPIC_API_KEY \
   --name embabel-demo \
@@ -100,7 +100,7 @@ docker run -d -p 48080:8080 \
 **OpenAI:**
 
 ```bash
-docker run -d -p 48080:8080 \
+docker run -d -p 48080:48080 \
   -e OPENAI_BASE_URL \
   -e OPENAI_API_KEY \
   --name embabel-demo \
@@ -110,7 +110,7 @@ docker run -d -p 48080:8080 \
 **Ollama:**
 
 ```bash
-docker run -d -p 48080:8080 \
+docker run -d -p 48080:48080 \
   --name embabel-demo \
   stevendoolan/embabel-demo:latest
 ```
@@ -140,7 +140,7 @@ The Docker image defaults to `claude-sonnet-4-5` as the default LLM.
 You can override the models using environment variables:
 
 ```bash
-docker run -d -p 48080:8080 \
+docker run -d -p 48080:48080 \
   -e EMBABEL_MODELS_DEFAULT_LLM=gpt-4.1 \
   -e EMBABEL_MODELS_LLMS_BEST=gpt-4.1 \
   -e EMBABEL_MODELS_LLMS_CHEAPEST=gpt-4.1-mini \

--- a/docs/updates.md
+++ b/docs/updates.md
@@ -57,7 +57,7 @@ How to use the Fibonacci Agent using the REST endpoint:
    mvn spring-boot:run -Popenai
    ```
 
-2. Send a GET request: http://localhost:8080/compute-fibonacci?iterations=10
+2. Send a GET request: http://localhost:48080/compute-fibonacci?iterations=10
 
 How to use the Fibonacci Agent using the Shell Client:
 1. Start the service with OpenAI and shell:

--- a/postman/embabel-demo.postman_collection.json
+++ b/postman/embabel-demo.postman_collection.json
@@ -12,12 +12,12 @@
 				"method": "GET",
 				"header": [],
 				"url": {
-					"raw": "http://localhost:8080/dad-joke?topic=programming",
+					"raw": "http://localhost:48080/dad-joke?topic=programming",
 					"protocol": "http",
 					"host": [
 						"localhost"
 					],
-					"port": "8080",
+					"port": "48080",
 					"path": [
 						"dad-joke"
 					],
@@ -37,12 +37,12 @@
 				"method": "GET",
 				"header": [],
 				"url": {
-					"raw": "http://localhost:8080/story?about=Steven",
+					"raw": "http://localhost:48080/story?about=Steven",
 					"protocol": "http",
 					"host": [
 						"localhost"
 					],
-					"port": "8080",
+					"port": "48080",
 					"path": [
 						"story"
 					],
@@ -71,12 +71,12 @@
 					}
 				},
 				"url": {
-					"raw": "http://localhost:8080/story",
+					"raw": "http://localhost:48080/story",
 					"protocol": "http",
 					"host": [
 						"localhost"
 					],
-					"port": "8080",
+					"port": "48080",
 					"path": [
 						"story"
 					]
@@ -105,12 +105,12 @@
 				"method": "POST",
 				"header": [],
 				"url": {
-					"raw": "http://localhost:8080/sonic-pi?prompt=frank sinatra croon",
+					"raw": "http://localhost:48080/sonic-pi?prompt=frank sinatra croon",
 					"protocol": "http",
 					"host": [
 						"localhost"
 					],
-					"port": "8080",
+					"port": "48080",
 					"path": [
 						"sonic-pi"
 					],
@@ -130,12 +130,12 @@
 				"method": "GET",
 				"header": [],
 				"url": {
-					"raw": "http://localhost:8080/sonic-pi/{{jobId}}",
+					"raw": "http://localhost:48080/sonic-pi/{{jobId}}",
 					"protocol": "http",
 					"host": [
 						"localhost"
 					],
-					"port": "8080",
+					"port": "48080",
 					"path": [
 						"sonic-pi",
 						"{{jobId}}"
@@ -150,12 +150,12 @@
 				"method": "GET",
 				"header": [],
 				"url": {
-					"raw": "http://localhost:8080/compute-fibonacci?iterations=10",
+					"raw": "http://localhost:48080/compute-fibonacci?iterations=10",
 					"protocol": "http",
 					"host": [
 						"localhost"
 					],
-					"port": "8080",
+					"port": "48080",
 					"path": [
 						"compute-fibonacci"
 					],

--- a/src/main/java/com/embabel/demo/controller/DadJokeController.java
+++ b/src/main/java/com/embabel/demo/controller/DadJokeController.java
@@ -15,7 +15,7 @@ import org.springframework.web.bind.annotation.RestController;
  * 1. Comment out "embabel-agent-starter-shell" in pom.xml to disable the shell.
  * 2. Run the application.
  * 3. Open a browser and go to:
- * <a href="http://localhost:8080/best-dad-joke?topic=chicken">http://localhost:8080/best-dad-joke?topic=chicken</a>
+ * <a href="http://localhost:48080/best-dad-joke?topic=chicken">http://localhost:48080/best-dad-joke?topic=chicken</a>
  */
 @RestController
 public record DadJokeController(AgentPlatform agentPlatform) {

--- a/src/main/java/com/embabel/demo/controller/StoryController.java
+++ b/src/main/java/com/embabel/demo/controller/StoryController.java
@@ -18,7 +18,7 @@ import org.springframework.web.bind.annotation.RestController;
  * 1. Comment out "embabel-agent-starter-shell" in pom.xml to disable the shell.
  * 2. Run the application.
  * 3. Open a browser and go to:
- * <a href="http://localhost:8080/story?about=Steven">http://localhost:8080/story?about=Steven</a>
+ * <a href="http://localhost:48080/story?about=Steven">http://localhost:48080/story?about=Steven</a>
  */
 @RestController
 public record StoryController(AgentPlatform agentPlatform) {

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,3 +1,6 @@
+server:
+  port: 48080
+
 # Enable virtual threads for better concurrency with LLM calls
 spring:
   threads:

--- a/src/test/java/com/embabel/demo/controller/RestControllerIntegrationTest.java
+++ b/src/test/java/com/embabel/demo/controller/RestControllerIntegrationTest.java
@@ -20,7 +20,7 @@ import org.slf4j.LoggerFactory;
 /**
  * End-to-end integration test for the REST controllers.
  * Requires the application to be running on localhost.
- * Port defaults to 48080 (Docker) and can be overridden with {@code -DTEST_PORT=8080}.
+ * Port defaults to 48080 and can be overridden with {@code -DTEST_PORT=<port>}.
  */
 @Tag("e2e")
 @Timeout(240)

--- a/src/test/java/com/embabel/demo/mcp/McpServerIntegrationTest.java
+++ b/src/test/java/com/embabel/demo/mcp/McpServerIntegrationTest.java
@@ -25,7 +25,7 @@ import org.slf4j.LoggerFactory;
 /**
  * Integration test for the MCP server SSE endpoint.
  * Requires the application to be running on localhost.
- * Port defaults to 48080 (Docker) and can be overridden with {@code -DTEST_PORT=8080}.
+ * Port defaults to 48080 and can be overridden with {@code -DTEST_PORT=<port>}.
  */
 @Tag("e2e")
 @Timeout(30)


### PR DESCRIPTION
## Summary
- Sets `server.port=48080` in `application.yml` so the app runs on 48080 natively
- Updates Dockerfile `EXPOSE`, Docker Compose and `docker-run.sh` port mappings from `48080:8080` to `48080:48080`
- Updates all docs, Postman collection, Javadoc links, and integration test comments to use 48080 consistently

## Test plan
- [ ] `mvn spring-boot:run` starts on port 48080
- [ ] `docker compose up --build` maps and serves on 48080
- [ ] `./docker-run.sh` maps and serves on 48080
- [ ] Postman collection requests hit 48080
- [ ] Grep confirms no remaining `localhost:8080` references (except proxy config examples)

🤖 Generated with [Claude Code](https://claude.com/claude-code)