### PR TITLE
Feed Sonic Pi example songs as few-shot context (#17)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,5 @@ embabel-agent-api/src/main/resources/mcp/**
 .mcp.json
 
 *.rb
+
+sonic-pi-examples/

--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,5 @@ embabel-agent-api/src/main/resources/mcp/**
 .ai/
 
 .mcp.json
+
+*.rb

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,5 +13,12 @@ FROM azul/zulu-openjdk:21-jre
 WORKDIR /app
 COPY --from=build /app/target/*.jar app.jar
 COPY config ./config
+
+# Sonic Pi example song directories - mount from host at runtime:
+#   docker run -v /Applications/Sonic Pi.app/Contents/Resources/etc/examples:/app/sonic-pi-examples \
+#              -v ~/code/sonicpi:/app/user-songs ...
+ENV SONIC_PI_EXAMPLES_SONIC_PI_APP_DIR=/app/sonic-pi-examples
+ENV SONIC_PI_EXAMPLES_USER_DIR=/app/user-songs
+
 EXPOSE 48080
 ENTRYPOINT ["java", "-jar", "app.jar", "--spring.config.additional-location=file:/app/config/all/"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,10 +14,5 @@ WORKDIR /app
 COPY --from=build /app/target/*.jar app.jar
 COPY config ./config
 
-# Sonic Pi example song directories - mount from host via docker-compose volumes.
-# Spring Boot relaxed binding: hyphens are removed when mapping to env vars.
-ENV SONICPI_EXAMPLES_SONICPIAPPDIR=/app/sonic-pi-examples
-ENV SONICPI_EXAMPLES_USERDIR=/app/user-songs
-
 EXPOSE 48080
 ENTRYPOINT ["java", "-jar", "app.jar", "--spring.config.additional-location=file:/app/config/all/"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,11 +14,10 @@ WORKDIR /app
 COPY --from=build /app/target/*.jar app.jar
 COPY config ./config
 
-# Sonic Pi example song directories - mount from host at runtime:
-#   docker run -v /Applications/Sonic Pi.app/Contents/Resources/etc/examples:/app/sonic-pi-examples \
-#              -v ~/code/sonicpi:/app/user-songs ...
-ENV SONIC_PI_EXAMPLES_SONIC_PI_APP_DIR=/app/sonic-pi-examples
-ENV SONIC_PI_EXAMPLES_USER_DIR=/app/user-songs
+# Sonic Pi example song directories - mount from host via docker-compose volumes.
+# Spring Boot relaxed binding: hyphens are removed when mapping to env vars.
+ENV SONICPI_EXAMPLES_SONICPIAPPDIR=/app/sonic-pi-examples
+ENV SONICPI_EXAMPLES_USERDIR=/app/user-songs
 
 EXPOSE 48080
 ENTRYPOINT ["java", "-jar", "app.jar", "--spring.config.additional-location=file:/app/config/all/"]

--- a/copy-sonic-pi-examples.sh
+++ b/copy-sonic-pi-examples.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+# Copies Sonic Pi .rb example songs into sonic-pi-examples/ for Docker volume mounting.
+# Run this before 'docker compose up'. Source directories that don't exist are skipped.
+# The destination directory is gitignored to avoid committing copyrighted material.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+DEST_DIR="$SCRIPT_DIR/sonic-pi-examples"
+
+SONIC_PI_APP_DIR="${SONIC_PI_EXAMPLES_DIR:-/Applications/Sonic Pi.app/Contents/Resources/etc/examples}"
+USER_SONGS_DIR="${SONIC_PI_USER_SONGS_DIR:-$HOME/code/sonicpi}"
+
+rm -rf "$DEST_DIR"
+mkdir -p "$DEST_DIR"
+
+copy_rb_files() {
+    local src="$1"
+    local label="$2"
+
+    if [ ! -d "$src" ]; then
+        echo "Skipping $label (directory not found: $src)"
+        return
+    fi
+
+    local count
+    count=$(find "$src" -name "*.rb" -type f | wc -l | tr -d ' ')
+    echo "Copying $count .rb files from $label ($src)"
+    rsync -a --include='*/' --include='*.rb' --exclude='*' "$src/" "$DEST_DIR/$label/"
+}
+
+copy_rb_files "$SONIC_PI_APP_DIR" "sonic-pi-app"
+copy_rb_files "$USER_SONGS_DIR" "user-songs"
+
+total=$(find "$DEST_DIR" -name "*.rb" -type f | wc -l | tr -d ' ')
+echo "Staged $total example songs in $DEST_DIR"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,6 +5,9 @@ services:
       dockerfile: Dockerfile
     ports:
       - "48080:48080"
+    volumes:
+      - ${SONIC_PI_EXAMPLES_DIR:-/Applications/Sonic Pi.app/Contents/Resources/etc/examples}:/app/sonic-pi-examples:ro
+      - ${SONIC_PI_USER_SONGS_DIR:-~/code/sonicpi}:/app/user-songs:ro
     environment:
       - ANTHROPIC_BASE_URL=${ANTHROPIC_BASE_URL}
       - ANTHROPIC_API_KEY=${ANTHROPIC_API_KEY}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,12 +6,11 @@ services:
     ports:
       - "48080:48080"
     volumes:
-      - ${SONIC_PI_EXAMPLES_DIR:-/Applications/Sonic Pi.app/Contents/Resources/etc/examples}:/app/sonic-pi-examples:ro
-      - ${SONIC_PI_USER_SONGS_DIR:-~/code/sonicpi}:/app/user-songs:ro
+      - ./sonic-pi-examples:/app/sonic-pi-examples:ro
     environment:
       - ANTHROPIC_BASE_URL=${ANTHROPIC_BASE_URL}
       - ANTHROPIC_API_KEY=${ANTHROPIC_API_KEY}
       - OPENAI_BASE_URL=${OPENAI_BASE_URL}
       - OPENAI_API_KEY=${OPENAI_API_KEY}
       - SPRING_AI_OLLAMA_BASE_URL=http://host.docker.internal:11434
-      - SPRING_APPLICATION_JSON={"sonic-pi":{"examples":{"sonic-pi-app-dir":"/app/sonic-pi-examples","user-dir":"/app/user-songs"}}}
+      - SPRING_APPLICATION_JSON={"sonic-pi":{"examples":{"sonic-pi-app-dir":"/app/sonic-pi-examples/sonic-pi-app","user-dir":"/app/sonic-pi-examples/user-songs"}}}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,3 +14,4 @@ services:
       - OPENAI_BASE_URL=${OPENAI_BASE_URL}
       - OPENAI_API_KEY=${OPENAI_API_KEY}
       - SPRING_AI_OLLAMA_BASE_URL=http://host.docker.internal:11434
+      - SPRING_APPLICATION_JSON={"sonic-pi":{"examples":{"sonic-pi-app-dir":"/app/sonic-pi-examples","user-dir":"/app/user-songs"}}}

--- a/src/main/java/com/embabel/demo/agent/SonicPiAgent.java
+++ b/src/main/java/com/embabel/demo/agent/SonicPiAgent.java
@@ -11,6 +11,7 @@ import com.embabel.demo.model.sonicpi.SonicPiMetadata;
 import com.embabel.demo.model.sonicpi.SonicPiScriptWithMelody;
 import com.embabel.demo.model.sonicpi.SonicPiScriptWithHarmony;
 import com.embabel.demo.model.sonicpi.SonicPiScriptWithPercussion;
+import com.embabel.demo.prompt.persona.SonicPiExamplesContributor;
 import com.embabel.demo.prompt.persona.SonicPiPromptContributor;
 import java.io.File;
 import java.time.Duration;
@@ -23,7 +24,8 @@ import org.slf4j.LoggerFactory;
 
 @Agent(description = "Write Sonic Pi code to play a melody based on user input")
 public record SonicPiAgent(
-        SonicPiPromptContributor sonicPiPromptContributor) {
+    SonicPiPromptContributor sonicPiPromptContributor,
+    SonicPiExamplesContributor sonicPiExamplesContributor) {
 
     private static final Logger LOG = LoggerFactory.getLogger(SonicPiAgent.class);
 
@@ -45,6 +47,7 @@ public record SonicPiAgent(
         return context.ai()
                 .withLlm(LlmOptions.withAutoLlm().withTemperature(1.0))
                 .withPromptContributor(sonicPiPromptContributor)
+                .withPromptContributor(sonicPiExamplesContributor)
                 .withTemplate("sonicpi/create-melody.jinja")
                 .createObject(SonicPiScriptWithMelody.class, Map.of(
                         "style", sonicPiMetadata.style(),
@@ -65,6 +68,7 @@ public record SonicPiAgent(
         LOG.info("Adding harmony track to {}", sonicPiScriptWithMelody);
         return context.ai()
                 .withLlm(LlmOptions.withAutoLlm().withTemperature(1.0))
+                .withPromptContributor(sonicPiExamplesContributor)
                 .withTemplate("sonicpi/add-harmony.jinja")
                 .createObject(SonicPiScriptWithHarmony.class, Map.of(
                         "melodyScriptContent", sonicPiScriptWithMelody.scriptContent(),
@@ -78,6 +82,7 @@ public record SonicPiAgent(
         LOG.info("Adding percussion track to {}", sonicPiScriptWithMelody);
         return context.ai()
                 .withLlm(LlmOptions.withAutoLlm().withTemperature(1.0))
+                .withPromptContributor(sonicPiExamplesContributor)
                 .withTemplate("sonicpi/add-percussion.jinja")
                 .createObject(SonicPiScriptWithPercussion.class, Map.of(
                         "melodyScriptContent", sonicPiScriptWithMelody.scriptContent(),
@@ -104,6 +109,7 @@ public record SonicPiAgent(
         var scriptContent = context.ai()
                 .withLlm(LlmOptions.withAutoLlm().withTemperature(1.0).withTimeout(Duration.ofSeconds(120)))
                 .withPromptContributor(sonicPiPromptContributor)
+                .withPromptContributor(sonicPiExamplesContributor)
                 .withTemplate("sonicpi/combine-all-parts.jinja")
                 .createObject(String.class, Map.of(
                         "melodyScriptContent", sonicPiScriptWithMelody.scriptContent(),

--- a/src/main/java/com/embabel/demo/agent/SonicPiAgent.java
+++ b/src/main/java/com/embabel/demo/agent/SonicPiAgent.java
@@ -36,6 +36,10 @@ public class SonicPiAgent {
         this.sonicPiExamplesContributor = sonicPiExamplesContributor;
     }
 
+    /**
+     * The reason for the SonicPiPromptContributor here is to provide data for the instruments
+     * in the SonicPiMetadata.
+     */
     @Action
     public SonicPiMetadata toSonicPiMetadata(UserInput userInput, OperationContext context) {
         LOG.info("Converting user input to {}", userInput);
@@ -75,6 +79,7 @@ public class SonicPiAgent {
         LOG.info("Adding harmony track to {}", sonicPiScriptWithMelody);
         return context.ai()
                 .withLlm(LlmOptions.withAutoLlm().withTemperature(1.0))
+                .withPromptContributor(sonicPiPromptContributor)
                 .withPromptContributor(sonicPiExamplesContributor)
                 .withTemplate("sonicpi/add-harmony.jinja")
                 .createObject(SonicPiScriptWithHarmony.class, Map.of(
@@ -89,6 +94,7 @@ public class SonicPiAgent {
         LOG.info("Adding percussion track to {}", sonicPiScriptWithMelody);
         return context.ai()
                 .withLlm(LlmOptions.withAutoLlm().withTemperature(1.0))
+                .withPromptContributor(sonicPiPromptContributor)
                 .withPromptContributor(sonicPiExamplesContributor)
                 .withTemplate("sonicpi/add-percussion.jinja")
                 .createObject(SonicPiScriptWithPercussion.class, Map.of(

--- a/src/main/java/com/embabel/demo/agent/SonicPiAgent.java
+++ b/src/main/java/com/embabel/demo/agent/SonicPiAgent.java
@@ -20,8 +20,15 @@ import java.util.Map;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-// TODO Use an document-recognition LLM to read a PDF of sheet music and convert it to Sonic Pi code.
-
+/**
+ * Embabel agent that converts a free-text user prompt into a runnable Sonic Pi Ruby script through
+ * a multi-step LLM pipeline: extract metadata, generate melody, add harmony, add percussion, and
+ * combine all tracks into a single script. Each step uses Jinja templates and prompt contributors
+ * for Sonic Pi instructions and example songs (few-shot context).
+ *
+ * <p>Exposed as an MCP tool via {@code @Export} so it can be invoked remotely.
+ */
+// TODO Use a document-recognition LLM to read a PDF of sheet music and convert it to Sonic Pi code.
 @Agent(description = "Write Sonic Pi code to play a melody based on user input")
 public class SonicPiAgent {
 

--- a/src/main/java/com/embabel/demo/agent/SonicPiAgent.java
+++ b/src/main/java/com/embabel/demo/agent/SonicPiAgent.java
@@ -23,11 +23,18 @@ import org.slf4j.LoggerFactory;
 // TODO Use an document-recognition LLM to read a PDF of sheet music and convert it to Sonic Pi code.
 
 @Agent(description = "Write Sonic Pi code to play a melody based on user input")
-public record SonicPiAgent(
-    SonicPiPromptContributor sonicPiPromptContributor,
-    SonicPiExamplesContributor sonicPiExamplesContributor) {
+public class SonicPiAgent {
 
     private static final Logger LOG = LoggerFactory.getLogger(SonicPiAgent.class);
+
+    private final SonicPiPromptContributor sonicPiPromptContributor;
+    private final SonicPiExamplesContributor sonicPiExamplesContributor;
+
+    public SonicPiAgent(SonicPiPromptContributor sonicPiPromptContributor,
+                        SonicPiExamplesContributor sonicPiExamplesContributor) {
+        this.sonicPiPromptContributor = sonicPiPromptContributor;
+        this.sonicPiExamplesContributor = sonicPiExamplesContributor;
+    }
 
     @Action
     public SonicPiMetadata toSonicPiMetadata(UserInput userInput, OperationContext context) {

--- a/src/main/java/com/embabel/demo/controller/SonicPiController.java
+++ b/src/main/java/com/embabel/demo/controller/SonicPiController.java
@@ -71,7 +71,7 @@ public class SonicPiController {
         return switch (job.status()) {
             case RUNNING -> ResponseEntity.status(HttpStatus.ACCEPTED)
                     .headers(headers)
-                    .body(null);
+                    .body("Job is still running");
             case COMPLETED -> ResponseEntity.ok()
                     .headers(headers)
                     .body(job.result());

--- a/src/main/java/com/embabel/demo/controller/SonicPiController.java
+++ b/src/main/java/com/embabel/demo/controller/SonicPiController.java
@@ -17,6 +17,11 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
+/**
+ * REST controller that exposes asynchronous Sonic Pi music generation. {@code POST /sonic-pi}
+ * accepts a free-text prompt and returns a job ID immediately; the agent pipeline runs in the
+ * background. {@code GET /sonic-pi/{jobId}} polls for the result (running, completed, or failed).
+ */
 @RestController
 public class SonicPiController {
 

--- a/src/main/java/com/embabel/demo/controller/SonicPiController.java
+++ b/src/main/java/com/embabel/demo/controller/SonicPiController.java
@@ -9,6 +9,7 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -57,11 +58,26 @@ public class SonicPiController {
     }
 
     @GetMapping("/sonic-pi/{jobId}")
-    public ResponseEntity<SonicPiJob> getJobStatus(@PathVariable String jobId) {
+    public ResponseEntity<String> getJobStatus(@PathVariable String jobId) {
         SonicPiJob job = jobs.get(jobId);
         if (job == null) {
             return ResponseEntity.notFound().build();
         }
-        return ResponseEntity.ok(job);
+
+        HttpHeaders headers = new HttpHeaders();
+        headers.set("X-Job-Id", job.jobId());
+        headers.set("X-Job-Status", job.status().name());
+
+        return switch (job.status()) {
+            case RUNNING -> ResponseEntity.status(HttpStatus.ACCEPTED)
+                    .headers(headers)
+                    .body(null);
+            case COMPLETED -> ResponseEntity.ok()
+                    .headers(headers)
+                    .body(job.result());
+            case FAILED -> ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
+                    .headers(headers)
+                    .body(job.error());
+        };
     }
 }

--- a/src/main/java/com/embabel/demo/controller/SonicPiJob.java
+++ b/src/main/java/com/embabel/demo/controller/SonicPiJob.java
@@ -1,13 +1,15 @@
 package com.embabel.demo.controller;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
+import jakarta.annotation.Nonnull;
+import jakarta.annotation.Nullable;
 
 @JsonInclude(JsonInclude.Include.NON_NULL)
 public record SonicPiJob(
-        String jobId,
-        Status status,
-        String result,
-        String error) {
+        @Nonnull String jobId,
+        @Nonnull Status status,
+        @Nullable String result,
+        @Nullable String error) {
 
     public enum Status {
         RUNNING, COMPLETED, FAILED

--- a/src/main/java/com/embabel/demo/controller/SonicPiJob.java
+++ b/src/main/java/com/embabel/demo/controller/SonicPiJob.java
@@ -4,6 +4,11 @@ import com.fasterxml.jackson.annotation.JsonInclude;
 import jakarta.annotation.Nonnull;
 import jakarta.annotation.Nullable;
 
+/**
+ * Represents the state of an asynchronous Sonic Pi generation job. Returned by
+ * {@link SonicPiController} as JSON, with null fields omitted. Factory methods
+ * {@link #running}, {@link #completed}, and {@link #failed} enforce valid state transitions.
+ */
 @JsonInclude(JsonInclude.Include.NON_NULL)
 public record SonicPiJob(
         @Nonnull String jobId,

--- a/src/main/java/com/embabel/demo/model/sonicpi/ExampleSong.java
+++ b/src/main/java/com/embabel/demo/model/sonicpi/ExampleSong.java
@@ -1,0 +1,4 @@
+package com.embabel.demo.model.sonicpi;
+
+public record ExampleSong(String name, String content) {
+}

--- a/src/main/java/com/embabel/demo/model/sonicpi/ExampleSong.java
+++ b/src/main/java/com/embabel/demo/model/sonicpi/ExampleSong.java
@@ -9,5 +9,7 @@ import jakarta.annotation.Nonnull;
  * @param name    relative file path within the source directory (e.g. "apprentice/bach.rb")
  * @param content the full Ruby source code of the song
  */
-public record ExampleSong(@Nonnull String name, @Nonnull String content) {
+public record ExampleSong(
+        @Nonnull String name,
+        @Nonnull String content) {
 }

--- a/src/main/java/com/embabel/demo/model/sonicpi/ExampleSong.java
+++ b/src/main/java/com/embabel/demo/model/sonicpi/ExampleSong.java
@@ -1,4 +1,11 @@
 package com.embabel.demo.model.sonicpi;
 
+/**
+ * Represents a Sonic Pi song loaded from disk, used as a few-shot example in LLM prompts
+ * to improve the quality of generated music.
+ *
+ * @param name    relative file path within the source directory (e.g. "apprentice/bach.rb")
+ * @param content the full Ruby source code of the song
+ */
 public record ExampleSong(String name, String content) {
 }

--- a/src/main/java/com/embabel/demo/model/sonicpi/ExampleSong.java
+++ b/src/main/java/com/embabel/demo/model/sonicpi/ExampleSong.java
@@ -1,5 +1,7 @@
 package com.embabel.demo.model.sonicpi;
 
+import jakarta.annotation.Nonnull;
+
 /**
  * Represents a Sonic Pi song loaded from disk, used as a few-shot example in LLM prompts
  * to improve the quality of generated music.
@@ -7,5 +9,5 @@ package com.embabel.demo.model.sonicpi;
  * @param name    relative file path within the source directory (e.g. "apprentice/bach.rb")
  * @param content the full Ruby source code of the song
  */
-public record ExampleSong(String name, String content) {
+public record ExampleSong(@Nonnull String name, @Nonnull String content) {
 }

--- a/src/main/java/com/embabel/demo/model/sonicpi/SonicPiCompleteScript.java
+++ b/src/main/java/com/embabel/demo/model/sonicpi/SonicPiCompleteScript.java
@@ -2,5 +2,6 @@ package com.embabel.demo.model.sonicpi;
 
 import jakarta.annotation.Nonnull;
 
-public record SonicPiCompleteScript(@Nonnull String scriptContent) {
+public record SonicPiCompleteScript(
+        @Nonnull String scriptContent) {
 }

--- a/src/main/java/com/embabel/demo/model/sonicpi/SonicPiCompleteScript.java
+++ b/src/main/java/com/embabel/demo/model/sonicpi/SonicPiCompleteScript.java
@@ -1,4 +1,6 @@
 package com.embabel.demo.model.sonicpi;
 
-public record SonicPiCompleteScript(String scriptContent) {
+import jakarta.annotation.Nonnull;
+
+public record SonicPiCompleteScript(@Nonnull String scriptContent) {
 }

--- a/src/main/java/com/embabel/demo/model/sonicpi/SonicPiCompleteScript.java
+++ b/src/main/java/com/embabel/demo/model/sonicpi/SonicPiCompleteScript.java
@@ -2,6 +2,11 @@ package com.embabel.demo.model.sonicpi;
 
 import jakarta.annotation.Nonnull;
 
+/**
+ * Holds the final combined Sonic Pi Ruby script after all tracks (melody, harmony, percussion)
+ * have been merged into a single runnable script. Used as part of {@link SonicPiScript} to pair
+ * the finished code with its metadata.
+ */
 public record SonicPiCompleteScript(
         @Nonnull String scriptContent) {
 }

--- a/src/main/java/com/embabel/demo/model/sonicpi/SonicPiMetadata.java
+++ b/src/main/java/com/embabel/demo/model/sonicpi/SonicPiMetadata.java
@@ -7,6 +7,12 @@ import jakarta.validation.constraints.NotEmpty;
 import jakarta.validation.constraints.Pattern;
 import java.util.List;
 
+/**
+ * Structured metadata extracted from a user's free-text music prompt by the LLM. Captures the
+ * musical properties (key, tempo, time signature, mood, instruments, etc.) needed to drive the
+ * multi-step Sonic Pi code generation pipeline. Produced by the {@code toSonicPiMetadata} action
+ * and consumed by every subsequent generation action in {@link com.embabel.demo.agent.SonicPiAgent}.
+ */
 public record SonicPiMetadata(
 
         @NotBlank(message = "Must not be blank.")

--- a/src/main/java/com/embabel/demo/model/sonicpi/SonicPiScript.java
+++ b/src/main/java/com/embabel/demo/model/sonicpi/SonicPiScript.java
@@ -1,12 +1,12 @@
 package com.embabel.demo.model.sonicpi;
 
-import org.jetbrains.annotations.NotNull;
+import jakarta.annotation.Nonnull;
 
 public record SonicPiScript(
-        SonicPiMetadata sonicPiMetadata,
-        SonicPiCompleteScript completeScript) {
+        @Nonnull SonicPiMetadata sonicPiMetadata,
+        @Nonnull SonicPiCompleteScript completeScript) {
 
-    public @NotNull String filename() {
+    public @Nonnull String filename() {
         return "sonic_pi_script_%s.rb".formatted(System.currentTimeMillis());
     }
 }

--- a/src/main/java/com/embabel/demo/model/sonicpi/SonicPiScript.java
+++ b/src/main/java/com/embabel/demo/model/sonicpi/SonicPiScript.java
@@ -2,6 +2,11 @@ package com.embabel.demo.model.sonicpi;
 
 import jakarta.annotation.Nonnull;
 
+/**
+ * Pairs the extracted {@link SonicPiMetadata} with the {@link SonicPiCompleteScript} to represent
+ * a fully generated Sonic Pi song, including both its musical properties and the runnable Ruby code.
+ * Provides a {@link #filename()} helper to generate a timestamped output file name.
+ */
 public record SonicPiScript(
         @Nonnull SonicPiMetadata sonicPiMetadata,
         @Nonnull SonicPiCompleteScript completeScript) {

--- a/src/main/java/com/embabel/demo/model/sonicpi/SonicPiScriptWithHarmony.java
+++ b/src/main/java/com/embabel/demo/model/sonicpi/SonicPiScriptWithHarmony.java
@@ -1,4 +1,6 @@
 package com.embabel.demo.model.sonicpi;
 
-public record SonicPiScriptWithHarmony(String scriptContent) {
+import jakarta.annotation.Nonnull;
+
+public record SonicPiScriptWithHarmony(@Nonnull String scriptContent) {
 }

--- a/src/main/java/com/embabel/demo/model/sonicpi/SonicPiScriptWithHarmony.java
+++ b/src/main/java/com/embabel/demo/model/sonicpi/SonicPiScriptWithHarmony.java
@@ -2,5 +2,6 @@ package com.embabel.demo.model.sonicpi;
 
 import jakarta.annotation.Nonnull;
 
-public record SonicPiScriptWithHarmony(@Nonnull String scriptContent) {
+public record SonicPiScriptWithHarmony(
+        @Nonnull String scriptContent) {
 }

--- a/src/main/java/com/embabel/demo/model/sonicpi/SonicPiScriptWithHarmony.java
+++ b/src/main/java/com/embabel/demo/model/sonicpi/SonicPiScriptWithHarmony.java
@@ -2,6 +2,11 @@ package com.embabel.demo.model.sonicpi;
 
 import jakarta.annotation.Nonnull;
 
+/**
+ * Holds the generated Sonic Pi Ruby code for the harmony track. Produced by the {@code addHarmony}
+ * action, which writes chords and progressions that complement the existing melody. Fed into the
+ * {@code combineAllSonicPiScripts} action to create the final arrangement.
+ */
 public record SonicPiScriptWithHarmony(
         @Nonnull String scriptContent) {
 }

--- a/src/main/java/com/embabel/demo/model/sonicpi/SonicPiScriptWithMelody.java
+++ b/src/main/java/com/embabel/demo/model/sonicpi/SonicPiScriptWithMelody.java
@@ -2,5 +2,6 @@ package com.embabel.demo.model.sonicpi;
 
 import jakarta.annotation.Nonnull;
 
-public record SonicPiScriptWithMelody(@Nonnull String scriptContent) {
+public record SonicPiScriptWithMelody(
+        @Nonnull String scriptContent) {
 }

--- a/src/main/java/com/embabel/demo/model/sonicpi/SonicPiScriptWithMelody.java
+++ b/src/main/java/com/embabel/demo/model/sonicpi/SonicPiScriptWithMelody.java
@@ -1,4 +1,6 @@
 package com.embabel.demo.model.sonicpi;
 
-public record SonicPiScriptWithMelody(String scriptContent) {
+import jakarta.annotation.Nonnull;
+
+public record SonicPiScriptWithMelody(@Nonnull String scriptContent) {
 }

--- a/src/main/java/com/embabel/demo/model/sonicpi/SonicPiScriptWithMelody.java
+++ b/src/main/java/com/embabel/demo/model/sonicpi/SonicPiScriptWithMelody.java
@@ -2,6 +2,11 @@ package com.embabel.demo.model.sonicpi;
 
 import jakarta.annotation.Nonnull;
 
+/**
+ * Holds the generated Sonic Pi Ruby code for the melody track. Produced by the {@code createMelody}
+ * action and passed to the harmony, percussion, and combine actions as the foundation that other
+ * tracks build upon.
+ */
 public record SonicPiScriptWithMelody(
         @Nonnull String scriptContent) {
 }

--- a/src/main/java/com/embabel/demo/model/sonicpi/SonicPiScriptWithPercussion.java
+++ b/src/main/java/com/embabel/demo/model/sonicpi/SonicPiScriptWithPercussion.java
@@ -1,4 +1,6 @@
 package com.embabel.demo.model.sonicpi;
 
-public record SonicPiScriptWithPercussion(String scriptContent) {
+import jakarta.annotation.Nonnull;
+
+public record SonicPiScriptWithPercussion(@Nonnull String scriptContent) {
 }

--- a/src/main/java/com/embabel/demo/model/sonicpi/SonicPiScriptWithPercussion.java
+++ b/src/main/java/com/embabel/demo/model/sonicpi/SonicPiScriptWithPercussion.java
@@ -2,6 +2,11 @@ package com.embabel.demo.model.sonicpi;
 
 import jakarta.annotation.Nonnull;
 
+/**
+ * Holds the generated Sonic Pi Ruby code for the percussion track. Produced by the
+ * {@code addPercussion} action using samples only (no instruments). Fed into the
+ * {@code combineAllSonicPiScripts} action to create the final arrangement.
+ */
 public record SonicPiScriptWithPercussion(
         @Nonnull String scriptContent) {
 }

--- a/src/main/java/com/embabel/demo/model/sonicpi/SonicPiScriptWithPercussion.java
+++ b/src/main/java/com/embabel/demo/model/sonicpi/SonicPiScriptWithPercussion.java
@@ -2,5 +2,6 @@ package com.embabel.demo.model.sonicpi;
 
 import jakarta.annotation.Nonnull;
 
-public record SonicPiScriptWithPercussion(@Nonnull String scriptContent) {
+public record SonicPiScriptWithPercussion(
+        @Nonnull String scriptContent) {
 }

--- a/src/main/java/com/embabel/demo/prompt/persona/SonicPiExamplesContributor.java
+++ b/src/main/java/com/embabel/demo/prompt/persona/SonicPiExamplesContributor.java
@@ -73,7 +73,7 @@ public class SonicPiExamplesContributor implements PromptContributor {
             return;
         }
 
-        var resolved = resolvePath(dirPath);
+        var resolved = Path.of(dirPath).toAbsolutePath().normalize();
         if (!Files.isDirectory(resolved)) {
             LOG.warn("Sonic Pi examples directory does not exist: {}", resolved);
             return;
@@ -99,13 +99,6 @@ public class SonicPiExamplesContributor implements PromptContributor {
 
         int loaded = target.size() - countBefore;
         LOG.info("Loaded {} example songs from {}", loaded, resolved);
-    }
-
-    private static Path resolvePath(String path) {
-        if (path.startsWith("~/")) {
-            return Path.of(System.getProperty("user.home")).resolve(path.substring(2)).toAbsolutePath().normalize();
-        }
-        return Path.of(path).toAbsolutePath().normalize();
     }
 
 }

--- a/src/main/java/com/embabel/demo/prompt/persona/SonicPiExamplesContributor.java
+++ b/src/main/java/com/embabel/demo/prompt/persona/SonicPiExamplesContributor.java
@@ -70,10 +70,12 @@ public class SonicPiExamplesContributor implements PromptContributor {
 
     private void loadFromDirectory(@Nullable String dirPath, @Nonnull List<ExampleSong> target) {
         if (dirPath == null || dirPath.isBlank()) {
+            LOG.info("Sonic Pi examples directory not configured (null or blank)");
             return;
         }
 
         var resolved = Path.of(dirPath).toAbsolutePath().normalize();
+        LOG.info("Loading Sonic Pi examples from: {}", resolved);
         if (!Files.isDirectory(resolved)) {
             LOG.warn("Sonic Pi examples directory does not exist: {}", resolved);
             return;

--- a/src/main/java/com/embabel/demo/prompt/persona/SonicPiExamplesContributor.java
+++ b/src/main/java/com/embabel/demo/prompt/persona/SonicPiExamplesContributor.java
@@ -53,8 +53,8 @@ public class SonicPiExamplesContributor implements PromptContributor {
 
         var sb = new StringBuilder();
         sb.append("""
-                Here are example Sonic Pi songs to learn from. \
-                Study these examples carefully and use them as inspiration for idiomatic Sonic Pi patterns, \
+                Here are example Sonic Pi songs to learn from.
+                Study these examples carefully and use them as inspiration for idiomatic Sonic Pi patterns,
                 richer arrangements, and more musical structures:
 
                 """);

--- a/src/main/java/com/embabel/demo/prompt/persona/SonicPiExamplesContributor.java
+++ b/src/main/java/com/embabel/demo/prompt/persona/SonicPiExamplesContributor.java
@@ -102,10 +102,10 @@ public class SonicPiExamplesContributor implements PromptContributor {
     }
 
     private static Path resolvePath(String path) {
-        if (path.startsWith("~")) {
-            return Path.of(System.getProperty("user.home") + path.substring(1));
+        if (path.startsWith("~/")) {
+            return Path.of(System.getProperty("user.home")).resolve(path.substring(2)).toAbsolutePath().normalize();
         }
-        return Path.of(path);
+        return Path.of(path).toAbsolutePath().normalize();
     }
 
 }

--- a/src/main/java/com/embabel/demo/prompt/persona/SonicPiExamplesContributor.java
+++ b/src/main/java/com/embabel/demo/prompt/persona/SonicPiExamplesContributor.java
@@ -2,6 +2,8 @@ package com.embabel.demo.prompt.persona;
 
 import com.embabel.common.ai.prompt.PromptContributor;
 import com.embabel.demo.model.sonicpi.ExampleSong;
+import jakarta.annotation.Nonnull;
+import jakarta.annotation.Nullable;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -9,7 +11,6 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.stream.Stream;
-import org.jetbrains.annotations.NotNull;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Component;
@@ -30,7 +31,7 @@ public class SonicPiExamplesContributor implements PromptContributor {
 
     private final List<ExampleSong> examples;
 
-    public SonicPiExamplesContributor(SonicPiExamplesProperties properties) {
+    public SonicPiExamplesContributor(@Nonnull SonicPiExamplesProperties properties) {
         List<ExampleSong> loaded = new ArrayList<>();
         loadFromDirectory(properties.sonicPiAppDir(), loaded);
         loadFromDirectory(properties.userDir(), loaded);
@@ -44,9 +45,8 @@ public class SonicPiExamplesContributor implements PromptContributor {
         LOG.info("Loaded {} Sonic Pi example songs for few-shot prompting", examples.size());
     }
 
-    @NotNull
     @Override
-    public String contribution() {
+    public @Nonnull String contribution() {
         if (examples.isEmpty()) {
             return "";
         }
@@ -68,7 +68,7 @@ public class SonicPiExamplesContributor implements PromptContributor {
         return sb.toString();
     }
 
-    private void loadFromDirectory(String dirPath, List<ExampleSong> target) {
+    private void loadFromDirectory(@Nullable String dirPath, @Nonnull List<ExampleSong> target) {
         if (dirPath == null || dirPath.isBlank()) {
             return;
         }

--- a/src/main/java/com/embabel/demo/prompt/persona/SonicPiExamplesContributor.java
+++ b/src/main/java/com/embabel/demo/prompt/persona/SonicPiExamplesContributor.java
@@ -14,6 +14,15 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Component;
 
+/**
+ * Loads Sonic Pi {@code .rb} example songs from configured directories at startup and contributes
+ * them to LLM prompts as few-shot context. Created because the Sonic Pi agent produces significantly
+ * richer, more idiomatic music when the LLM can learn from concrete examples of real songs.
+ *
+ * <p>Recursively scans two optional directories (Sonic Pi's built-in examples and the user's
+ * personal collection) and caps the total at {@code maxExamples} to avoid exceeding context limits.
+ * Gracefully handles missing or unreadable directories.
+ */
 @Component
 public class SonicPiExamplesContributor implements PromptContributor {
 

--- a/src/main/java/com/embabel/demo/prompt/persona/SonicPiExamplesContributor.java
+++ b/src/main/java/com/embabel/demo/prompt/persona/SonicPiExamplesContributor.java
@@ -1,6 +1,7 @@
 package com.embabel.demo.prompt.persona;
 
 import com.embabel.common.ai.prompt.PromptContributor;
+import com.embabel.demo.model.sonicpi.ExampleSong;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -95,6 +96,4 @@ public class SonicPiExamplesContributor implements PromptContributor {
         return Path.of(path);
     }
 
-    private record ExampleSong(String name, String content) {
-    }
 }

--- a/src/main/java/com/embabel/demo/prompt/persona/SonicPiExamplesContributor.java
+++ b/src/main/java/com/embabel/demo/prompt/persona/SonicPiExamplesContributor.java
@@ -1,0 +1,100 @@
+package com.embabel.demo.prompt.persona;
+
+import com.embabel.common.ai.prompt.PromptContributor;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.stream.Stream;
+import org.jetbrains.annotations.NotNull;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Component;
+
+@Component
+public class SonicPiExamplesContributor implements PromptContributor {
+
+    private static final Logger LOG = LoggerFactory.getLogger(SonicPiExamplesContributor.class);
+
+    private final List<ExampleSong> examples;
+
+    public SonicPiExamplesContributor(SonicPiExamplesProperties properties) {
+        List<ExampleSong> loaded = new ArrayList<>();
+        loadFromDirectory(properties.sonicPiAppDir(), loaded);
+        loadFromDirectory(properties.userDir(), loaded);
+
+        if (loaded.size() > properties.maxExamples()) {
+            Collections.shuffle(loaded);
+            loaded = loaded.subList(0, properties.maxExamples());
+        }
+
+        this.examples = List.copyOf(loaded);
+        LOG.info("Loaded {} Sonic Pi example songs for few-shot prompting", examples.size());
+    }
+
+    @NotNull
+    @Override
+    public String contribution() {
+        if (examples.isEmpty()) {
+            return "";
+        }
+
+        var sb = new StringBuilder();
+        sb.append("""
+                Here are example Sonic Pi songs to learn from. \
+                Study these examples carefully and use them as inspiration for idiomatic Sonic Pi patterns, \
+                richer arrangements, and more musical structures:
+
+                """);
+
+        for (var example : examples) {
+            sb.append("<example name=\"%s\">\n".formatted(example.name()));
+            sb.append(example.content());
+            sb.append("\n</example>\n\n");
+        }
+
+        return sb.toString();
+    }
+
+    private void loadFromDirectory(String dirPath, List<ExampleSong> target) {
+        if (dirPath == null || dirPath.isBlank()) {
+            return;
+        }
+
+        var resolved = resolvePath(dirPath);
+        if (!Files.isDirectory(resolved)) {
+            LOG.warn("Sonic Pi examples directory does not exist: {}", resolved);
+            return;
+        }
+
+        try (Stream<Path> walk = Files.walk(resolved)) {
+            walk.filter(Files::isRegularFile)
+                    .filter(p -> p.toString().endsWith(".rb"))
+                    .forEach(p -> {
+                        try {
+                            var content = Files.readString(p);
+                            var name = resolved.relativize(p).toString();
+                            target.add(new ExampleSong(name, content));
+                        } catch (IOException e) {
+                            LOG.warn("Failed to read example file: {}", p, e);
+                        }
+                    });
+        } catch (IOException e) {
+            LOG.warn("Failed to scan directory: {}", resolved, e);
+        }
+
+        LOG.info("Loaded {} example songs from {}", target.size(), resolved);
+    }
+
+    private static Path resolvePath(String path) {
+        if (path.startsWith("~")) {
+            return Path.of(System.getProperty("user.home") + path.substring(1));
+        }
+        return Path.of(path);
+    }
+
+    private record ExampleSong(String name, String content) {
+    }
+}

--- a/src/main/java/com/embabel/demo/prompt/persona/SonicPiExamplesContributor.java
+++ b/src/main/java/com/embabel/demo/prompt/persona/SonicPiExamplesContributor.java
@@ -79,6 +79,7 @@ public class SonicPiExamplesContributor implements PromptContributor {
             return;
         }
 
+        int countBefore = target.size();
         try (Stream<Path> walk = Files.walk(resolved)) {
             walk.filter(Files::isRegularFile)
                     .filter(p -> p.toString().endsWith(".rb"))
@@ -87,6 +88,7 @@ public class SonicPiExamplesContributor implements PromptContributor {
                             var content = Files.readString(p);
                             var name = resolved.relativize(p).toString();
                             target.add(new ExampleSong(name, content));
+                            LOG.info("  Loaded example song: {}", name);
                         } catch (IOException e) {
                             LOG.warn("Failed to read example file: {}", p, e);
                         }
@@ -95,7 +97,8 @@ public class SonicPiExamplesContributor implements PromptContributor {
             LOG.warn("Failed to scan directory: {}", resolved, e);
         }
 
-        LOG.info("Loaded {} example songs from {}", target.size(), resolved);
+        int loaded = target.size() - countBefore;
+        LOG.info("Loaded {} example songs from {}", loaded, resolved);
     }
 
     private static Path resolvePath(String path) {

--- a/src/main/java/com/embabel/demo/prompt/persona/SonicPiExamplesProperties.java
+++ b/src/main/java/com/embabel/demo/prompt/persona/SonicPiExamplesProperties.java
@@ -1,5 +1,6 @@
 package com.embabel.demo.prompt.persona;
 
+import jakarta.annotation.Nullable;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 
 /**
@@ -13,8 +14,8 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
  */
 @ConfigurationProperties("sonic-pi.examples")
 public record SonicPiExamplesProperties(
-        String sonicPiAppDir,
-        String userDir,
+        @Nullable String sonicPiAppDir,
+        @Nullable String userDir,
         int maxExamples
 ) {
 }

--- a/src/main/java/com/embabel/demo/prompt/persona/SonicPiExamplesProperties.java
+++ b/src/main/java/com/embabel/demo/prompt/persona/SonicPiExamplesProperties.java
@@ -1,0 +1,11 @@
+package com.embabel.demo.prompt.persona;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@ConfigurationProperties("sonic-pi.examples")
+public record SonicPiExamplesProperties(
+        String sonicPiAppDir,
+        String userDir,
+        int maxExamples
+) {
+}

--- a/src/main/java/com/embabel/demo/prompt/persona/SonicPiExamplesProperties.java
+++ b/src/main/java/com/embabel/demo/prompt/persona/SonicPiExamplesProperties.java
@@ -2,6 +2,15 @@ package com.embabel.demo.prompt.persona;
 
 import org.springframework.boot.context.properties.ConfigurationProperties;
 
+/**
+ * Configuration properties for locating Sonic Pi example songs on the local filesystem.
+ * Created to allow the Sonic Pi agent to load real {@code .rb} songs as few-shot examples,
+ * dramatically improving the quality of LLM-generated music.
+ *
+ * @param sonicPiAppDir path to Sonic Pi's built-in examples directory (may be null if not installed)
+ * @param userDir       path to the user's personal Sonic Pi song collection (may be null)
+ * @param maxExamples   maximum number of example songs to include in prompts, to bound context size
+ */
 @ConfigurationProperties("sonic-pi.examples")
 public record SonicPiExamplesProperties(
         String sonicPiAppDir,

--- a/src/main/java/com/embabel/demo/prompt/persona/SonicPiPromptContributor.java
+++ b/src/main/java/com/embabel/demo/prompt/persona/SonicPiPromptContributor.java
@@ -6,6 +6,11 @@ import java.util.List;
 import java.util.stream.Collectors;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 
+/**
+ * Contributes Sonic Pi programming instructions, available instruments, and available samples to
+ * every LLM prompt in the Sonic Pi agent pipeline. Bound from the {@code sonic-pi} configuration
+ * block in {@code application.yml} so the lists can be maintained without code changes.
+ */
 @ConfigurationProperties("sonic-pi")
 public record SonicPiPromptContributor(
         @Nonnull String instructions,

--- a/src/main/java/com/embabel/demo/prompt/persona/SonicPiPromptContributor.java
+++ b/src/main/java/com/embabel/demo/prompt/persona/SonicPiPromptContributor.java
@@ -1,21 +1,20 @@
 package com.embabel.demo.prompt.persona;
 
 import com.embabel.common.ai.prompt.PromptContributor;
+import jakarta.annotation.Nonnull;
 import java.util.List;
 import java.util.stream.Collectors;
-import org.jetbrains.annotations.NotNull;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 
 @ConfigurationProperties("sonic-pi")
 public record SonicPiPromptContributor(
-        @NotNull String instructions,
-        @NotNull List<String> instruments,
-        @NotNull List<String> samples
+        @Nonnull String instructions,
+        @Nonnull List<String> instruments,
+        @Nonnull List<String> samples
 ) implements PromptContributor {
 
-    @NotNull
     @Override
-    public String contribution() {
+    public @Nonnull String contribution() {
         return """
                 %s
                 
@@ -30,7 +29,7 @@ public record SonicPiPromptContributor(
                 toJSONList(samples));
     }
 
-    private static @NotNull String toJSONList(@NotNull List<String> items) {
+    private static @Nonnull String toJSONList(@Nonnull List<String> items) {
         return items.stream()
                 .map("\"%s\""::formatted)
                 .collect(Collectors.joining(", "));

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -37,7 +37,7 @@ spring:
 sonic-pi:
   examples:
     sonic-pi-app-dir: /Applications/Sonic Pi.app/Contents/Resources/etc/examples/
-    user-dir: ~/code/sonicpi/
+    user-dir: ${user.home}/code/sonicpi/
     max-examples: 20
 
   instructions: |

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -35,6 +35,11 @@ spring:
 #                - run
 
 sonic-pi:
+  examples:
+    sonic-pi-app-dir: /Applications/Sonic Pi.app/Contents/Resources/etc/examples/
+    user-dir: ~/code/sonicpi/
+    max-examples: 20
+
   instructions: |
     You are an expert Sonic Pi programmer, familiar with music theory and composition.
     You are a musician skilled in various genres and styles.

--- a/src/main/resources/prompts/sonicpi/add-harmony.jinja
+++ b/src/main/resources/prompts/sonicpi/add-harmony.jinja
@@ -20,3 +20,22 @@ Provide a comment at the top of the script content with the song title.
 Do not include the melody again; only provide the harmony part in the harmonyScriptContent.
 Be aware of the existing instruments used in the melody to avoid clashes.
 Be aware of the key changes in the melody when composing the harmony.
+
+Use audio FX to add depth and texture to the harmony:
+- `:reverb` with `room:` 0-1 creates spacious pads and atmospheric chords
+- `:echo` with `phase:` and `decay:` adds rhythmic repeats that fill out the sound
+- Nest FX blocks to chain effects (e.g., reverb around echo for a lush, spacious delay)
+- Always wrap `with_fx` OUTSIDE loops — never create a new FX per iteration
+
+Example of effective harmony FX:
+```
+with_fx :reverb, room: 1 do
+  16.times do
+    use_synth :dsaw
+    play 28, cutoff: 130, release: 0.1, amp: 2
+    sleep 0.125
+    play 28 + 12, cutoff: 80, release: 0.1, amp: 2
+    sleep 0.125
+  end
+end
+```

--- a/src/main/resources/prompts/sonicpi/add-harmony.jinja
+++ b/src/main/resources/prompts/sonicpi/add-harmony.jinja
@@ -24,18 +24,28 @@ Be aware of the key changes in the melody when composing the harmony.
 Use audio FX to add depth and texture to the harmony:
 - `:reverb` with `room:` 0-1 creates spacious pads and atmospheric chords
 - `:echo` with `phase:` and `decay:` adds rhythmic repeats that fill out the sound
-- Nest FX blocks to chain effects (e.g., reverb around echo for a lush, spacious delay)
-- Always wrap `with_fx` OUTSIDE loops — never create a new FX per iteration
+
+FX rules:
+- Place `with_fx` INSIDE `live_loop` blocks, not wrapping them from outside.
+- Wrap `with_fx` outside inner loops (e.g., `N.times do`) for efficiency.
+- Nest at most 2 FX blocks deep. Use FX selectively — not every loop needs FX.
 
 Example of effective harmony FX:
 ```
-with_fx :reverb, room: 1 do
-  16.times do
-    use_synth :dsaw
-    play 28, cutoff: 130, release: 0.1, amp: 2
-    sleep 0.125
-    play 28 + 12, cutoff: 80, release: 0.1, amp: 2
-    sleep 0.125
+live_loop :harmony do
+  with_fx :reverb, room: 1 do
+    16.times do
+      use_synth :dsaw
+      play 28, cutoff: 130, release: 0.1, amp: 2
+      sleep 0.125
+      play 28 + 12, cutoff: 80, release: 0.1, amp: 2
+      sleep 0.125
+    end
   end
 end
 ```
+
+Script structure rules:
+- Use at most 3 `live_loop` blocks for the harmony part.
+- Use `.times do` loops inside `live_loop` to repeat patterns — do not write out every bar individually.
+- Keep the script concise.

--- a/src/main/resources/prompts/sonicpi/add-percussion.jinja
+++ b/src/main/resources/prompts/sonicpi/add-percussion.jinja
@@ -24,16 +24,28 @@ Use audio FX on percussion to add punch and character:
 - `:echo` with `phase:` and `decay:` creates rhythmic ghost hits
 - `:distortion` adds weight and grit to drum samples
 - `:slicer` chops percussion into rhythmic patterns
-- Always wrap `with_fx` OUTSIDE loops — never create a new FX per iteration
+
+FX rules:
+- Place `with_fx` INSIDE `live_loop` blocks, not wrapping them from outside.
+- Wrap `with_fx` outside inner loops (e.g., `N.times do`) for efficiency.
+- Nest at most 2 FX blocks deep. Use FX selectively — not every loop needs FX.
 
 Example of effective percussion FX:
 ```
-with_fx :reverb, room: 1 do
-  2.times do
-    sample :bd_haus, amp: 4
-    use_synth :tb303
-    play 28, cutoff: 110, release: 0.1, amp: 2
-    sleep 0.125
+live_loop :drums do
+  with_fx :reverb, room: 0.3 do
+    2.times do
+      sample :bd_haus, amp: 4
+      sleep 0.5
+      sample :elec_snare, amp: 2
+      sleep 0.5
+    end
   end
 end
 ```
+
+Script structure rules:
+- Use at most 3 `live_loop` blocks for the percussion part.
+- Do not duplicate drum elements across multiple loops (e.g., do not have a separate loop for kick, snare, and hi-hat when they can be combined).
+- Use `.times do` loops inside `live_loop` to repeat patterns — do not write out every bar individually.
+- Keep the script concise.

--- a/src/main/resources/prompts/sonicpi/add-percussion.jinja
+++ b/src/main/resources/prompts/sonicpi/add-percussion.jinja
@@ -18,3 +18,22 @@ Do not use instruments. Only use samples.
 Create a rich, full sound using drums, bass, synths, and pads.
 Do not include the melody again; only provide the percussion part in the percussionScriptContent.
 Make the percussion louder than the melody to provide a strong rhythmic foundation.
+
+Use audio FX on percussion to add punch and character:
+- `:reverb` with `room:` 0-1 gives drums space and presence
+- `:echo` with `phase:` and `decay:` creates rhythmic ghost hits
+- `:distortion` adds weight and grit to drum samples
+- `:slicer` chops percussion into rhythmic patterns
+- Always wrap `with_fx` OUTSIDE loops — never create a new FX per iteration
+
+Example of effective percussion FX:
+```
+with_fx :reverb, room: 1 do
+  2.times do
+    sample :bd_haus, amp: 4
+    use_synth :tb303
+    play 28, cutoff: 110, release: 0.1, amp: 2
+    sleep 0.125
+  end
+end
+```

--- a/src/main/resources/prompts/sonicpi/combine-all-parts.jinja
+++ b/src/main/resources/prompts/sonicpi/combine-all-parts.jinja
@@ -20,3 +20,5 @@ Do not duplicate any parts; ensure each section is included only once.
 Ensure the BPM is set once for the entire script.
 Ensure the different instruments are applied correctly to their respective parts.
 Write a comment above each section to identify what the section contains.
+Preserve all `with_fx` blocks from the individual parts — do not strip FX when combining.
+Ensure FX blocks wrap OUTSIDE loops, not inside them.

--- a/src/main/resources/prompts/sonicpi/combine-all-parts.jinja
+++ b/src/main/resources/prompts/sonicpi/combine-all-parts.jinja
@@ -21,4 +21,7 @@ Ensure the BPM is set once for the entire script.
 Ensure the different instruments are applied correctly to their respective parts.
 Write a comment above each section to identify what the section contains.
 Preserve all `with_fx` blocks from the individual parts — do not strip FX when combining.
-Ensure FX blocks wrap OUTSIDE loops, not inside them.
+Ensure all `with_fx` blocks are INSIDE `live_loop` blocks, not wrapping them from outside.
+The combined script must have at most 8 `live_loop` blocks total. Merge similar loops if needed to stay within this limit.
+Remove any duplicate drum or percussion loops — consolidate into fewer loops.
+Use `.times do` loops for repeating patterns — do not write out every bar individually. Keep the script concise.

--- a/src/main/resources/prompts/sonicpi/create-melody.jinja
+++ b/src/main/resources/prompts/sonicpi/create-melody.jinja
@@ -48,7 +48,7 @@ Use the following instruments:
 {{ melodyInstruments }}
 </melodyInstruments>
 
-Use audio FX liberally to add depth and character. Wrap sections in `with_fx` blocks:
+Use audio FX to add depth and character. Available FX:
 - `:reverb` adds space and atmosphere (use `room:` 0-1 to control size)
 - `:echo` creates rhythmic repeats (use `phase:` for delay in beats, `decay:` for fade time)
 - `:distortion` adds grit and edge
@@ -56,20 +56,28 @@ Use audio FX liberally to add depth and character. Wrap sections in `with_fx` bl
 - `:slicer` chops the sound rhythmically
 
 FX rules:
-- Wrap `with_fx` OUTSIDE loops for efficiency — never create a new FX instance per iteration.
-- Nest multiple FX blocks to chain effects (inner FX processes first, outer processes the result).
-- Use FX parameters to shape the sound — e.g., `with_fx :reverb, room: 1` or `with_fx :echo, phase: 0.375`.
+- Place `with_fx` INSIDE `live_loop` blocks, not wrapping them from outside. This keeps FX scoped to each loop's iteration.
+- Wrap `with_fx` outside inner loops (e.g., `N.times do`) for efficiency — never create a new FX instance per iteration.
+- Nest at most 2 FX blocks deep to avoid overloading the audio engine.
+- Use FX parameters to shape the sound — e.g., `with_fx :reverb, room: 0.6` or `with_fx :echo, phase: 0.375`.
+- Use FX selectively — not every `live_loop` needs FX. Pick 2-3 loops that benefit most.
 
-Example of FX used well:
+Example of FX used correctly inside a live_loop:
 ```
-with_fx :echo, phase: 0.375 do
-  sample :arovane_beat_c, beat_stretch: 8, amp: 4
+live_loop :melody do
+  with_fx :reverb, room: 0.6 do
+    with_fx :echo, phase: 0.375, decay: 4 do
+      use_synth :fm
+      play 28, release: 8, divisor: 4, depth: 20
+      sleep 8
+    end
+  end
 end
+```
 
-with_fx :reverb, room: 1 do
-  use_synth :fm
-  play 28, release: 8, divisor: 4, depth: 20
-end
-```
+Script structure rules:
+- Use at most 2 `live_loop` blocks for the melody part.
+- Use `.times do` loops inside `live_loop` to repeat patterns — do not write out every bar individually.
+- Keep the script concise. Repetitive patterns should use loops, not copy-paste.
 
 Provide a comment at the top of the script content with the song title.

--- a/src/main/resources/prompts/sonicpi/create-melody.jinja
+++ b/src/main/resources/prompts/sonicpi/create-melody.jinja
@@ -48,4 +48,28 @@ Use the following instruments:
 {{ melodyInstruments }}
 </melodyInstruments>
 
+Use audio FX liberally to add depth and character. Wrap sections in `with_fx` blocks:
+- `:reverb` adds space and atmosphere (use `room:` 0-1 to control size)
+- `:echo` creates rhythmic repeats (use `phase:` for delay in beats, `decay:` for fade time)
+- `:distortion` adds grit and edge
+- `:wobble` adds movement
+- `:slicer` chops the sound rhythmically
+
+FX rules:
+- Wrap `with_fx` OUTSIDE loops for efficiency — never create a new FX instance per iteration.
+- Nest multiple FX blocks to chain effects (inner FX processes first, outer processes the result).
+- Use FX parameters to shape the sound — e.g., `with_fx :reverb, room: 1` or `with_fx :echo, phase: 0.375`.
+
+Example of FX used well:
+```
+with_fx :echo, phase: 0.375 do
+  sample :arovane_beat_c, beat_stretch: 8, amp: 4
+end
+
+with_fx :reverb, room: 1 do
+  use_synth :fm
+  play 28, release: 8, divisor: 4, depth: 20
+end
+```
+
 Provide a comment at the top of the script content with the song title.


### PR DESCRIPTION
## Summary
- Adds configurable directories (`sonic-pi.examples.sonic-pi-app-dir` and `sonic-pi.examples.user-dir`) for loading example Sonic Pi `.rb` songs
- Creates `SonicPiExamplesContributor` that recursively scans both directories at startup and injects example songs into prompts as few-shot context
- Wires the contributor into all music generation actions (melody, harmony, percussion, combine) so the LLM can learn idiomatic patterns from real songs
- Adds `*.rb` to `.gitignore` to prevent accidental commits of copyrighted material or generated scripts
- Both directories are optional — the agent starts and operates normally when either or both don't exist
- Extracts `ExampleSong` to top-level record in `model.sonicpi` package
- Converts `SonicPiAgent` from record to class with constructor injection
- Returns job ID and status as response headers; body is result or error only
- Returns body message when job is still running instead of empty response
- Adds Docker support: volume mounts, env var overrides via `SPRING_APPLICATION_JSON`, and `copy-sonic-pi-examples.sh` staging script
- Improved logging: logs directory paths before loading and when not configured
- Adds FX guidance (reverb, echo, distortion, wobble, slicer) to all prompt templates with idiomatic examples and efficiency rules
- Adds resource constraints to prevent audio overload: FX inside live_loops, max 2 FX deep, capped live_loop counts (8 total), concise loop patterns

Closes #17

## Test plan
- [x] Verify `mvn compile` succeeds
- [x] Run the app with both example directories present — check logs show examples loaded
- [ ] Run the app with neither directory present — verify graceful startup with 0 examples
- [x] Hit `POST /sonic-pi` and compare output quality vs. prior runs without examples
- [x] Verify `.rb` files are not tracked by git
- [x] Build and run Docker image — verify volume mounts expose example songs inside container
- [x] Verify `copy-sonic-pi-examples.sh` stages files correctly to local staging directory
- [x] Verify generated songs include `with_fx` blocks for richer audio
- [x] Verify generated scripts stay within resource limits (max 8 live_loops, no excessive FX nesting)

🤖 Generated with [Claude Code](https://claude.com/claude-code)