### PR TITLE
Add bass track as parallel action in SonicPiAgent (#22)

### DIFF
--- a/docs/sonic-pi/20260430-073742/Electronic Classical Fusion.rb
+++ b/docs/sonic-pi/20260430-073742/Electronic Classical Fusion.rb
@@ -1,0 +1,264 @@
+# Electronic Classical Fusion
+# Style: Electronic Classical Fusion
+# Mood: Dramatic and atmospheric
+
+use_debug false
+use_bpm 120
+
+with_fx :level, amp: 1.2 do
+  with_fx :compressor, threshold: 0.4, clamp_time: 0.01, relax_time: 0.1, slope_above: 0.5 do
+    
+    # Section 1: Opening atmospheric statement - Light percussion foundation
+    2.times do
+      use_synth :prophet
+      play 36, release: 16, cutoff: 85, amp: 0.5
+      
+      in_thread do
+        with_fx :reverb, room: 0.35, mix: 0.35 do
+          use_synth :dark_ambience
+          play_chord chord(:c3, :major), cutoff: 85, release: 16, amp: 8
+        end
+      end
+
+      in_thread do
+        use_synth :bass_foundation
+        play :c2, cutoff: 70, release: 8, amp: 0.7
+      end
+      
+      in_thread do
+        with_fx :lpf, cutoff: 110, mix: 0.8 do
+          with_fx :reverb, room: 0.25, mix: 0.3 do
+            melody_notes = (ring :c4, :e4, :g4, :c5, :g4, :e4, :d4, :c4)
+            cutoffs = (line 90, 120, steps: 16)
+            
+            16.times do
+              play melody_notes.tick, cutoff: cutoffs.look, release: 0.2, amp: 0.9
+              sleep 0.25
+            end
+          end
+        end
+      end
+      
+      in_thread do
+        with_fx :reverb, room: 0.35, mix: 0.35 do
+          use_synth :hollow
+          chord_progression = [chord(:c3, :major), chord(:a3, :minor), chord(:f3, :major), chord(:g3, :major)]
+          cutoff_sweep = (line 80, 105, steps: 4)
+          
+          4.times do
+            play_chord chord_progression.tick, cutoff: cutoff_sweep.look, release: 3.5, amp: 0.55
+            sleep 4
+          end
+        end
+      end
+      
+      in_thread do
+        with_fx :lpf, cutoff: 75, mix: 0.8 do
+          bass_pattern = (ring :c2, :c2, :e2, :g2)
+          4.times do
+            play bass_pattern.tick, cutoff: 72, release: 3.5, amp: 0.65
+            sleep 4
+          end
+        end
+      end
+      
+      in_thread do
+        with_fx :hpf, cutoff: 100 do
+          16.times do
+            sample :elec_tick, amp: 0.35, rate: 1.5
+            sleep 0.25
+            sample :elec_tick, amp: 0.25, rate: 1.2 if one_in(2)
+            sleep 0.25
+            sample :drum_heavy_kick, amp: 0.5 if spread(3, 8).tick
+            sample :hat_zild, amp: 0.3, rate: 1.3
+            sleep 0.25
+            sample :elec_tick, amp: 0.25, rate: 1.2
+            sleep 0.25
+          end
+        end
+      end
+      
+      sleep 16
+    end
+    
+    # Transition: Prophet drone bridges sections
+    use_synth :prophet
+    play 36, cutoff: 90, release: 10, amp: 0.6
+    sleep 4
+    
+    # Section 2: Building intensity with arpeggiated chords and stronger kick
+    2.times do
+      use_synth :prophet
+      play 36, release: 16, cutoff: 85, amp: 0.4
+      
+      in_thread do
+        use_synth :dark_ambience
+        play_chord chord(:c3, :major), cutoff: 88, release: 16, amp: 9
+      end
+
+      in_thread do
+        use_synth :tb303
+        play :c2, cutoff: 80, release: 7, res: 0.6, amp: 0.7
+      end
+      
+      in_thread do
+        use_synth :saw
+        melody_notes = (ring :c4, :d4, :e4, :g4, :a4, :g4, :e4, :c4)
+        dynamics = (line 80, 125, steps: 16)
+        
+        16.times do
+          play melody_notes.tick, cutoff: dynamics.look, release: 0.15, amp: 0.95
+          sleep 0.25
+        end
+      end
+      
+      in_thread do
+        with_fx :lpf, cutoff: 100, mix: 0.8 do
+          use_synth :mod_sine
+          chord_progression = [chord(:c3, :major), chord(:d3, :minor), chord(:e3, :minor), chord(:g3, :major)]
+          
+          4.times do
+            current_chord = chord_progression.tick
+            4.times do
+              play current_chord.choose, cutoff: rrand(85, 110), release: 0.8, amp: 0.6
+              sleep 1
+            end
+          end
+        end
+      end
+      
+      in_thread do
+        bass_notes = (ring :c2, :c2, :g2, :c2, :e2, :g2, :f2, :c2)
+        8.times do
+          play bass_notes.tick, cutoff: 78, release: 1.5, res: 0.5, amp: 0.65
+          sleep 2
+        end
+      end
+      
+      in_thread do
+        16.times do
+          sample :drum_heavy_kick, amp: 0.6
+          sample :hat_zild, amp: 0.35, rate: 1.4
+          sleep 0.25
+          sample :elec_tick, amp: 0.4, rate: 1.3
+          sleep 0.25
+          sample :elec_snare, amp: 0.5
+          sample :hat_zild, amp: 0.35, rate: 1.4
+          sleep 0.25
+          sample :elec_tick, amp: 0.35, rate: 1.2
+          sleep 0.25
+        end
+      end
+      
+      sleep 16
+    end
+    
+    # Transition: FM drone with longer release
+    use_synth :fm
+    play 36, cutoff: 95, release: 12, divisor: 6, depth: 20, amp: 0.6
+    sleep 4
+    
+    # Section 3: Climactic finale with full orchestral-inspired percussion
+    3.times do
+      use_synth :prophet
+      play 36, release: 16, cutoff: 80, amp: 0.45
+      
+      in_thread do
+        with_fx :reverb, room: 0.4, mix: 0.4 do
+          use_synth :dark_ambience
+          play_chord chord(:c3, :major), cutoff: 82, release: 16, amp: 10
+        end
+      end
+
+      in_thread do
+        use_synth :subpulse
+        play :c2, cutoff: 75, release: 8, amp: 0.75
+      end
+      
+      in_thread do
+        with_fx :reverb, room: 0.3, mix: 0.35 do
+          use_synth :prophet
+          climax_notes = (ring :c5, :e5, :d5, :c5, :g4, :a4, :c5, :d5, :e5, :g5, :e5, :d5, :c5, :g4, :e4, :c4)
+          cutoff_sweep = (line 100, 130, steps: 16)
+          
+          16.times do
+            play climax_notes.tick, cutoff: cutoff_sweep.look, release: 0.18, amp: 1.0
+            sleep 0.25
+          end
+        end
+      end
+      
+      in_thread do
+        with_fx :reverb, room: 0.4, mix: 0.4 do
+          use_synth :hollow
+          chord_progression = [chord(:c3, :major), chord(:e3, :minor), chord(:d3, :minor7), chord(:g3, :major)]
+          cutoff_evolution = (line 90, 125, steps: 4)
+          
+          4.times do
+            play_chord chord_progression.tick, cutoff: cutoff_evolution.look, release: 3.8, amp: 0.65
+            sleep 4
+          end
+        end
+      end
+      
+      in_thread do
+        use_synth :tb303
+        climax_bass = (ring :c2, :e2, :g2, :c2, :f2, :g2, :c2, :g2)
+        8.times do
+          play climax_bass.tick, cutoff: 82, release: 1.8, res: 0.6, amp: 0.7
+          sleep 2
+        end
+      end
+      
+      in_thread do
+        with_fx :reverb, room: 0.25, mix: 0.25 do
+          16.times do |i|
+            kick_amp = i == 0 ? 0.7 : 0.6
+            sample :drum_heavy_kick, amp: kick_amp
+            sample :hat_zild, amp: 0.4, rate: 1.5
+            sleep 0.25
+            sample :elec_tick, amp: 0.5, rate: 1.4
+            sample :hat_zild, amp: 0.3, rate: 1.3 if one_in(2)
+            sleep 0.25
+            sample :elec_snare, amp: 0.6
+            sample :hat_zild, amp: 0.4, rate: 1.5
+            sleep 0.25
+            sample :elec_tick, amp: 0.45, rate: 1.2
+            sample :drum_heavy_kick, amp: 0.5 if spread(5, 16).tick
+            sleep 0.25
+          end
+        end
+      end
+      
+      sleep 16
+    end
+    
+    # Final sustained fade with sparse percussion
+    use_synth :prophet
+    play 36, cutoff: 90, release: 16, amp: 0.5
+    
+    in_thread do
+      use_synth :dark_ambience
+      play_chord chord(:c3, :major), cutoff: 90, release: 16, amp: 0.6
+      use_synth :hollow
+      play_chord chord(:c4, :major), cutoff: 95, release: 16, amp: 0.5
+    end
+
+    in_thread do
+      use_synth :bass_foundation
+      play :c2, cutoff: 65, release: 16, amp: 0.75
+    end
+    
+    in_thread do
+      4.times do
+        sample :drum_heavy_kick, amp: 0.4
+        sleep 1
+        sample :elec_tick, amp: 0.3, rate: 1.0
+        sleep 1
+      end
+    end
+    
+    sleep 8
+    
+  end
+end

--- a/docs/sonic-pi/20260430-073742/Electronic Dreams.rb
+++ b/docs/sonic-pi/20260430-073742/Electronic Dreams.rb
@@ -1,0 +1,225 @@
+# Electronic Dreams
+# Style: Dreamy electronic journey
+# Mood: Atmospheric and hypnotic
+
+use_debug false
+use_bpm 128
+
+with_fx :level, amp: 1.2 do
+  with_fx :compressor, threshold: 0.4, clamp_time: 0.01, relax_time: 0.1, slope_above: 0.5 do
+    
+    # Section 1: Dreamy opening in Am - atmospheric foundation with minimal percussion
+    2.times do
+      in_thread do
+        use_synth :fm
+        play :a2, release: 16, divisor: 4, depth: 10, cutoff: 85, amp: 0.4
+      end
+      
+      in_thread do
+        with_fx :reverb, room: 0.35, mix: 0.3 do
+          use_synth :dark_ambience
+          play_chord chord(:a3, :minor), cutoff: 85, release: 16, amp: 0.4
+        end
+      end
+      
+      in_thread do
+        use_synth :bass_foundation
+        play :a1, cutoff: 70, release: 8, amp: 0.6
+        sleep 4
+        with_fx :lpf, cutoff: 75, mix: 0.25 do
+          use_synth :tb303
+          bass_pattern = (ring :a1, :a1, :e2, :c2)
+          4.times do
+            play bass_pattern.tick, cutoff: 72, release: 0.8, res: 0.6, amp: 0.5
+            sleep 1
+          end
+        end
+      end
+      
+      in_thread do
+        with_fx :lpf, cutoff: 110, mix: 0.25 do
+          with_fx :reverb, room: 0.25, mix: 0.25 do
+            use_synth :fm
+            melody_notes = (ring :a4, :c5, :e5, :a5, :g5, :e5, :c5, :a4)
+            16.times do |i|
+              play melody_notes.tick, cutoff: (line 90, 115, steps: 16).tick, release: 0.3, amp: 0.9
+              sleep 0.25
+            end
+          end
+        end
+      end
+      
+      in_thread do
+        with_fx :reverb, room: 0.35, mix: 0.3 do
+          use_synth :hollow
+          8.times do |i|
+            play_chord chord(:a3, :minor), cutoff: (line 80, 105, steps: 8).tick, release: 0.5, amp: 0.35
+            sleep 0.5
+          end
+        end
+      end
+      
+      16.times do |i|
+        sample :bd_haus, amp: (i % 4 == 0 ? 0.5 : 0.35) if spread(8, 16)[i]
+        sample :hat_psych, amp: 0.2, rate: 1.2, cutoff: 100
+        sample :elec_tick, amp: 0.15, rate: rrand(0.8, 1.5), cutoff: 110 if one_in(6)
+        sleep 0.25
+      end
+    end
+    
+    # Transition drone - bridges to next section
+    use_synth :prophet
+    play :a2, cutoff: 90, release: 8, amp: 0.6
+    sleep 4
+    
+    # Section 2: Building intensity with four-on-the-floor - still Am
+    2.times do
+      in_thread do
+        use_synth :blade
+        play :a2, release: 12, cutoff: 80, amp: 0.3
+      end
+      
+      in_thread do
+        use_synth :prophet
+        play_chord chord(:a2, :minor7), cutoff: 90, release: 12, amp: 0.45
+      end
+      
+      in_thread do
+        use_synth :bass_foundation
+        play :a1, cutoff: 75, release: 6, amp: 0.6
+        sleep 2
+        use_synth :chipbass
+        walking_bass = (knit :a1, 2, :c2, 1, :e2, 1, :g2, 2, :e2, 1, :c2, 1)
+        8.times do
+          play walking_bass.tick, cutoff: 80, release: 0.5, amp: 0.5
+          sleep 0.5
+        end
+      end
+      
+      in_thread do
+        use_synth :prophet
+        harmony = (knit :a3, 4, :c4, 2, :e4, 2, :g4, 4, :e4, 2, :c4, 2)
+        16.times do
+          play harmony.tick, cutoff: rrand(95, 120), release: 0.25, amp: 0.85
+          sleep 0.25
+        end
+      end
+      
+      in_thread do
+        with_fx :echo, phase: 0.5, decay: 1.5, mix: 0.2 do
+          use_synth :hollow
+          harmony_progression = (knit chord(:a3, :minor), 4, chord(:c4, :major), 2, chord(:e3, :minor), 2, chord(:g3, :major), 4, chord(:e3, :minor), 2, chord(:c4, :major), 2)
+          16.times do
+            play_chord harmony_progression.tick, cutoff: rrand(90, 115), release: 0.4, amp: 0.4
+            sleep 0.25
+          end
+        end
+      end
+      
+      with_fx :hpf, cutoff: 90, mix: 0.25 do
+        16.times do |i|
+          sample :bd_haus, amp: (i % 4 == 0 ? 0.6 : 0.45), cutoff: 95
+          sample :hat_psych, amp: (i % 2 == 0 ? 0.25 : 0.15), rate: 1.1, cutoff: 105
+          sleep 0.25
+          if (i % 4 == 1) or (i % 4 == 3)
+            sample :elec_hi_snare, amp: 0.45, cutoff: 100
+          end
+          sample :elec_tick, amp: 0.2, rate: rrand(1, 2), cutoff: 110 if one_in(8)
+          sleep 0.25
+        end
+      end
+    end
+    
+    # Transition drone with key change preparation
+    use_synth :fm
+    play :c3, cutoff: 95, release: 10, divisor: 8, depth: 15, amp: 0.5
+    sleep 4
+    
+    # Section 3: Key change to C major - lush resolution with full intensity
+    3.times do
+      in_thread do
+        use_synth :prophet
+        play :c3, release: 14, cutoff: 88, amp: 0.35
+      end
+      
+      in_thread do
+        with_fx :reverb, room: 0.4, mix: 0.3 do
+          use_synth :prophet
+          play_chord chord(:c3, :major7), cutoff: 85, release: 14, amp: 0.5
+        end
+      end
+      
+      in_thread do
+        use_synth :bass_foundation
+        play :c2, cutoff: 78, release: 7, amp: 0.6
+        sleep 2
+        use_synth :tb303
+        c_bass = (ring :c2, :c2, :g2, :e2, :f2, :c2, :g2, :c2)
+        8.times do
+          play c_bass.tick, cutoff: 75, release: 0.7, res: 0.65, amp: 0.5
+          sleep 0.5
+        end
+      end
+      
+      in_thread do
+        with_fx :reverb, room: 0.3, mix: 0.25 do
+          use_synth :blade
+          c_major_melody = (ring :c5, :e5, :g5, :c6, :b5, :g5, :e5, :c5, :d5, :f5, :a5, :g5, :e5, :c5, :d5, :e5)
+          16.times do |i|
+            play c_major_melody.tick, cutoff: (line 85, 125, steps: 16).tick, release: 0.2, amp: 0.95
+            sleep 0.25
+          end
+        end
+      end
+      
+      in_thread do
+        with_fx :reverb, room: 0.4, mix: 0.3 do
+          use_synth :hollow
+          c_major_chords = (ring chord(:c4, :major), chord(:f3, :major), chord(:g3, :major), chord(:a3, :minor))
+          16.times do |i|
+            play_chord c_major_chords.tick, cutoff: (line 82, 118, steps: 16).tick, release: 0.35, amp: 0.35
+            sleep 0.25
+          end
+        end
+      end
+      
+      with_fx :reverb, room: 0.25, mix: 0.2 do
+        16.times do |i|
+          sample :bd_haus, amp: (i % 4 == 0 ? 0.7 : 0.5), cutoff: 100
+          sample :hat_psych, amp: 0.3, rate: 1.15, cutoff: 105
+          sleep 0.25
+          if (i % 4 == 1) or (i % 4 == 3)
+            sample :elec_hi_snare, amp: 0.5, cutoff: 100
+          elsif one_in(3)
+            sample :elec_hi_snare, amp: 0.25, rate: 1.2, cutoff: 105
+          end
+          sample :elec_tick, amp: 0.25, rate: rrand(0.5, 2), cutoff: 110 if one_in(5)
+          sleep 0.25
+        end
+      end
+    end
+    
+    # Final fade - minimal percussion with sustained drone
+    in_thread do
+      use_synth :fm
+      play :c3, release: 12, divisor: 6, depth: 18, cutoff: 82, amp: 0.4
+    end
+    
+    in_thread do
+      use_synth :dark_ambience
+      play_chord chord(:c3, :major), release: 12, cutoff: 80, amp: 0.4
+    end
+    
+    in_thread do
+      use_synth :bass_foundation
+      play :c2, cutoff: 70, release: 10, amp: 0.5
+    end
+    
+    8.times do |i|
+      sample :bd_haus, amp: (line 0.4, 0.15, steps: 8).tick, cutoff: 95
+      sample :hat_psych, amp: (line 0.2, 0.08, steps: 8).look, rate: 1.1, cutoff: 100
+      sleep 1
+    end
+    
+  end
+end

--- a/docs/sonic-pi/20260430-073742/Feed the Birds EDM Remix.rb
+++ b/docs/sonic-pi/20260430-073742/Feed the Birds EDM Remix.rb
@@ -1,0 +1,248 @@
+# Feed the Birds EDM Remix
+# Style: electronic, Mood: uplifting
+
+use_debug false
+use_bpm 128
+
+with_fx :level, amp: 1.2 do
+  with_fx :compressor, threshold: 0.4, clamp_time: 0.01, relax_time: 0.1, slope_above: 0.5 do
+    
+    # Section 1: Atmospheric intro with melody, harmony, and minimal percussion
+    2.times do
+      use_synth :prophet
+      play :c2, release: 16, cutoff: 85, amp: 0.5
+      
+      in_thread do
+        use_synth :prophet
+        play_chord chord(:c3, :major7), cutoff: 85, release: 16, amp: 0.4
+      end
+      
+      in_thread do
+        with_fx :reverb, room: 0.35, mix: 0.3 do
+          use_synth :dark_ambience
+          chords_prog = (ring chord(:c3, :major7), chord(:g2, :sus4))
+          2.times do
+            play_chord chords_prog.tick, cutoff: 80, release: 4, amp: 0.3
+            sleep 2
+          end
+        end
+      end
+      
+      in_thread do
+        with_fx :reverb, room: 0.25, mix: 0.25 do
+          use_synth :saw
+          melody = (ring :g4, :g4, :fs4, :e4, :g4, :e4, :d4, :c4)
+          releases = (ring 0.4, 0.2, 0.5, 0.2, 0.4, 0.2, 0.5, 1.0)
+          cutoffs = (ring 95, 100, 90, 105, 95, 100, 90, 85)
+          8.times do
+            play melody.tick, release: releases.look, cutoff: cutoffs.look, amp: 0.9
+            sleep 0.5
+          end
+        end
+      end
+      
+      in_thread do
+        use_synth :bass_foundation
+        play :c2, cutoff: 65, release: 8, amp: 0.5
+        sleep 2
+        play :g2, cutoff: 70, release: 2, amp: 0.4
+        sleep 1
+        play :c2, cutoff: 65, release: 1, amp: 0.45
+        sleep 1
+      end
+      
+      in_thread do
+        8.times do
+          sample :hat_psych, amp: 0.25, rate: 1.2
+          sleep 0.25
+          sample :hat_psych, amp: 0.15, rate: 1.3
+          sleep 0.25
+        end
+      end
+    end
+    
+    # Transition drone
+    use_synth :fm
+    play :c2, cutoff: 90, release: 8, amp: 0.6, divisor: 4, depth: 15
+    in_thread do
+      use_synth :hollow
+      play_chord chord(:c3, :major7), cutoff: 85, release: 8, amp: 0.5
+    end
+    in_thread do
+      use_synth :bass_foundation
+      play :c2, cutoff: 60, release: 8, amp: 0.55
+    end
+    sleep 4
+    
+    # Section 2: Energetic pluck melody with bass and building rhythm
+    3.times do
+      use_synth :prophet
+      play :c2, release: 12, cutoff: 80, amp: 0.4
+      
+      in_thread do
+        use_synth :prophet
+        play_chord chord(:c3, :major7), cutoff: 90, release: 12, amp: 0.45
+      end
+      
+      in_thread do
+        with_fx :lpf, cutoff: 100, mix: 0.25 do
+          use_synth :dark_ambience
+          chords_prog = knit(chord(:c3, :major7), 2, chord(:f3, :major7), 2, chord(:g3, :sus4), 2, chord(:c3, :major7), 2)
+          cutoffs = (line 85, 110, steps: 8)
+          8.times do
+            play_chord chords_prog.tick, cutoff: cutoffs.look, release: 0.5, amp: 0.35
+            sleep 0.5
+          end
+        end
+      end
+      
+      in_thread do
+        with_fx :lpf, cutoff: 110, mix: 0.25 do
+          with_fx :echo, phase: 0.5, decay: 1.5, mix: 0.2 do
+            use_synth :pluck
+            melody = (ring :g4, :g4, :fs4, :e4, :g4, :e4, :d4, :c4)
+            cutoffs = (line 90, 120, steps: 8)
+            8.times do
+              play melody.tick, release: 0.3, cutoff: cutoffs.tick, amp: 1.0
+              sleep 0.5
+            end
+          end
+        end
+      end
+      
+      in_thread do
+        with_fx :lpf, cutoff: 85, mix: 0.25 do
+          use_synth :tb303
+          bass_pattern = (ring :c2, :c2, :g2, :c2, :f2, :g2, :c2, :c2)
+          cutoffs = (line 70, 90, steps: 8)
+          8.times do
+            play bass_pattern.tick, cutoff: cutoffs.tick, release: 0.5, res: 0.7, amp: 0.5
+            sleep 0.5
+          end
+        end
+      end
+      
+      in_thread do
+        with_fx :hpf, cutoff: 100, mix: 0.25 do
+          4.times do
+            sample :bd_haus, amp: 0.5
+            sample :hat_psych, amp: 0.3, rate: 1.2
+            sleep 0.25
+            sample :hat_psych, amp: 0.2, rate: 1.3
+            sleep 0.25
+            sample :elec_snare, amp: 0.4
+            sample :hat_psych, amp: 0.3, rate: 1.2
+            sleep 0.25
+            sample :hat_psych, amp: 0.2, rate: 1.3
+            sleep 0.25
+          end
+        end
+      end
+    end
+    
+    # Transition drone
+    use_synth :saw
+    play :c2, cutoff: 95, release: 8, amp: 0.6
+    in_thread do
+      use_synth :hollow
+      play_chord chord(:f3, :major7), cutoff: 90, release: 8, amp: 0.5
+    end
+    in_thread do
+      use_synth :bass_foundation
+      play :g2, cutoff: 70, release: 8, amp: 0.5
+    end
+    sleep 4
+    
+    # Section 3: Peak energy with beep lead, full percussion, and pumping bass
+    4.times do
+      use_synth :fm
+      play :c2, release: 10, cutoff: 85, amp: 0.3, divisor: 6, depth: 18
+      
+      in_thread do
+        use_synth :prophet
+        play_chord chord(:c3, :major7), cutoff: 95, release: 10, amp: 0.5
+      end
+      
+      in_thread do
+        with_fx :reverb, room: 0.3, mix: 0.3 do
+          use_synth :hollow
+          arp_notes = (scale :c3, :major_pentatonic)
+          8.times do
+            play arp_notes.tick, cutoff: rrand(95, 115), release: 0.2, amp: 0.4
+            sleep 0.5
+          end
+        end
+      end
+      
+      in_thread do
+        use_synth :beep
+        melody = (ring :g5, :g5, :fs5, :e5, :g5, :e5, :d5, :c5)
+        cutoffs = (ring 110, 115, 105, 120, 110, 115, 100, 95)
+        8.times do |i|
+          play melody.tick, release: 0.2, cutoff: cutoffs.look, amp: 0.95
+          sleep 0.5
+        end
+      end
+      
+      in_thread do
+        use_synth :chipbass
+        bass_notes = (ring :c2, :c3, :c2, :g2, :c2, :c3, :f2, :g2)
+        releases = (ring 0.4, 0.3, 0.4, 0.6, 0.4, 0.3, 0.5, 0.7)
+        8.times do |i|
+          amp_val = (i % 2 == 0) ? 0.55 : 0.35
+          play bass_notes.tick, cutoff: 80, release: releases.look, amp: amp_val
+          sleep 0.5
+        end
+      end
+      
+      in_thread do
+        4.times do |i|
+          sample :bd_haus, amp: 0.6
+          sample :hat_psych, amp: 0.35, rate: 1.2
+          sleep 0.125
+          sample :hat_psych, amp: 0.25, rate: 1.4
+          sleep 0.125
+          
+          if i == 1 || i == 3
+            sample :elec_snare, amp: 0.5
+            sample :elec_cymbal, amp: 0.4, rate: 1.5
+          end
+          
+          sample :hat_psych, amp: 0.3, rate: 1.3
+          sleep 0.125
+          sample :hat_psych, amp: 0.2, rate: 1.5
+          sleep 0.125
+          
+          sample :bd_haus, amp: 0.55
+          sample :hat_psych, amp: 0.35, rate: 1.2
+          sleep 0.125
+          sample :hat_psych, amp: 0.25, rate: 1.4
+          sleep 0.125
+          
+          if i == 1 || i == 3
+            sample :elec_snare, amp: 0.45
+          end
+          
+          sample :hat_psych, amp: 0.3, rate: 1.3
+          sleep 0.125
+          sample :hat_psych, amp: 0.2, rate: 1.5
+          sleep 0.125
+        end
+      end
+    end
+    
+    # Final transition drone to close
+    use_synth :prophet
+    play :c2, cutoff: 90, release: 12, amp: 0.7
+    in_thread do
+      use_synth :prophet
+      play_chord chord(:c3, :major7), cutoff: 85, release: 12, amp: 0.55
+    end
+    in_thread do
+      use_synth :bass_foundation
+      play :c2, cutoff: 65, release: 12, amp: 0.55
+    end
+    sleep 4
+    
+  end
+end

--- a/docs/sonic-pi/20260430-073742/Java User Group Dance Anthem.rb
+++ b/docs/sonic-pi/20260430-073742/Java User Group Dance Anthem.rb
@@ -1,0 +1,219 @@
+# Java User Group Dance Anthem
+# Electronic dance track in C major, 128 BPM, 4/4 time
+# Style: Electronic Dance
+# Mood: Energetic and uplifting
+
+use_debug false
+use_bpm 128
+
+with_fx :level, amp: 1.2 do
+  with_fx :compressor, threshold: 0.4, clamp_time: 0.01, relax_time: 0.1, slope_above: 0.5 do
+    
+    # Section 1: Opening in C major - Supersaw lead with atmospheric drone
+    3.times do
+      with_fx :reverb, room: 0.3, mix: 0.3 do
+        use_synth :prophet
+        play :c2, release: 8, cutoff: 90, amp: 0.5
+        
+        use_synth :prophet
+        play_chord chord(:c3, :major), cutoff: 85, release: 16, amp: 0.5
+        
+        use_synth :subpulse
+        play :c2, cutoff: 70, release: 8, amp: 0.6
+        
+        with_fx :lpf, cutoff: 100, mix: 0.8 do
+          use_synth :supersaw
+          melody_c = (ring :c4, :e4, :g4, :a4, :g4, :e4, :d4, :c4)
+          cutoffs = (line 80, 110, steps: 8)
+          
+          use_synth :tech_saws
+          chords_c = (ring chord(:c4, :major), chord(:f4, :major), chord(:g4, :major), chord(:a4, :minor))
+          
+          use_synth :tb303
+          bass_pattern_c = (ring :c2, :c2, :g2, :c2, :c2, :g2, :f2, :g2)
+          
+          2.times do
+            with_fx :hpf, cutoff: 90, mix: 0.8 do
+              8.times do
+                use_synth :supersaw
+                play melody_c.tick, release: 0.2, cutoff: cutoffs.look, amp: 0.9
+                
+                if look % 2 == 0
+                  use_synth :tech_saws
+                  play_chord chords_c.look / 2, cutoff: 95, release: 0.8, amp: 0.5
+                end
+                
+                use_synth :tb303
+                play bass_pattern_c.look, cutoff: 75, release: 0.4, res: 0.7, amp: 0.7
+                
+                sample :bd_haus, amp: 0.7
+                sample :hat_psych, amp: 0.3
+                sleep 0.25
+                sample :hat_psych, amp: 0.2
+                sleep 0.25
+              end
+            end
+          end
+        end
+      end
+    end
+    
+    # Transition - Long drone bridges to next section
+    use_synth :fm
+    play :c2, cutoff: 90, release: 8, divisor: 4, depth: 15, amp: 0.6
+    use_synth :prophet
+    play_chord chord(:c3, :major7), cutoff: 90, release: 8, amp: 0.55
+    use_synth :bass_foundation
+    play :c2, cutoff: 70, release: 8, amp: 0.55
+    2.times do
+      sample :bd_haus, amp: 0.6
+      sleep 1
+      sample :elec_hi_snare, amp: 0.4
+      sleep 1
+    end
+    
+    # Section 2: Build energy - Chiplead with rhythmic variation
+    3.times do
+      use_synth :fm
+      play :c2, release: 12, cutoff: 85, amp: 0.4
+      
+      use_synth :prophet
+      play_chord chord(:c3, :major), cutoff: 88, release: 12, amp: 0.5
+      
+      use_synth :bass_foundation
+      play :c2, cutoff: 75, release: 12, amp: 0.55
+      
+      use_synth :chiplead
+      melody_energetic = (ring :e4, :g4, :a4, :c5, :a4, :g4, :f4, :e4)
+      
+      with_fx :lpf, cutoff: 100, mix: 0.8 do
+        use_synth :supersaw
+        progression = (knit chord(:c4, :major), 2, chord(:a3, :minor), 2, chord(:f3, :major), 2, chord(:g3, :major), 2)
+        cutoff_line = (line 85, 115, steps: 8)
+        
+        use_synth :tb303
+        walking_bass = (ring :c2, :e2, :g2, :a2, :g2, :e2, :f2, :c2)
+        
+        8.times do |n|
+          with_fx :hpf, cutoff: 90, mix: 0.8 do
+            2.times do
+              use_synth :chiplead
+              play melody_energetic.tick, release: 0.15, cutoff: rrand(90, 115), amp: 0.95
+              
+              use_synth :tb303
+              play walking_bass.look, cutoff: 80, release: 0.5, res: 0.75, amp: 0.7
+              
+              kick_amp = n == 0 ? 0.8 : 0.7
+              sample :bd_haus, amp: kick_amp
+              sample :hat_psych, amp: 0.35
+              sleep 0.25
+              sample :hat_psych, amp: 0.25
+              sleep 0.25
+            end
+            
+            if look % 2 == 0
+              use_synth :supersaw
+              play_chord progression.look / 2, cutoff: cutoff_line.look / 2, release: 1.5, amp: 0.5
+            end
+            
+            sample :elec_hi_snare, amp: 0.6
+            sample :hat_psych, amp: 0.35
+            sample :elec_cymbal, amp: 0.3 if one_in(4)
+            sleep 0.25
+            sample :hat_psych, amp: 0.25
+            sleep 0.25
+          end
+        end
+      end
+    end
+    
+    # Transition - Sustained drone into key change
+    use_synth :prophet
+    play :f2, cutoff: 95, release: 10, amp: 0.6
+    use_synth :prophet
+    play_chord chord(:f3, :major7), cutoff: 92, release: 10, amp: 0.55
+    use_synth :subpulse
+    play :f2, cutoff: 72, release: 10, amp: 0.6
+    2.times do
+      sample :bd_haus, amp: 0.6
+      sleep 0.5
+      sample :hat_psych, amp: 0.25
+      sleep 0.5
+      sample :elec_hi_snare, amp: 0.5
+      sample :elec_cymbal, amp: 0.25
+      sleep 1
+    end
+    
+    # Section 3: Key change to F major - FM synth with echo effect
+    4.times do
+      with_fx :reverb, room: 0.35, mix: 0.35 do
+        use_synth :prophet
+        play :f2, release: 10, cutoff: 88, amp: 0.45
+        
+        use_synth :prophet
+        play_chord chord(:f3, :major), cutoff: 90, release: 16, amp: 0.55
+        
+        use_synth :bass_foundation
+        play :f2, cutoff: 70, release: 10, amp: 0.55
+        
+        with_fx :echo, phase: 0.375, decay: 1.5, mix: 0.25 do
+          use_synth :fm
+          melody_f = (ring :f4, :a4, :c5, :d5, :c5, :a4, :g4, :f4)
+          cutoff_mod = (line 85, 120, steps: 8)
+          
+          use_synth :tech_saws
+          f_progression = (ring chord(:f4, :major), chord(:bb3, :major), chord(:c4, :major), chord(:d4, :minor))
+          
+          use_synth :tb303
+          bass_pattern_f = (ring :f2, :f2, :c3, :f2, :f2, :c3, :g2, :c3)
+          
+          2.times do
+            with_fx :reverb, room: 0.25, mix: 0.25 do
+              8.times do |n|
+                use_synth :fm
+                play melody_f.tick, release: 0.25, cutoff: cutoff_mod.look, divisor: 0.5, depth: 8, amp: 1.0
+                
+                if look % 2 == 0
+                  use_synth :tech_saws
+                  play_chord f_progression.look / 2, cutoff: (line 90, 120, steps: 8).look / 2, release: 1.2, amp: 0.5
+                end
+                
+                use_synth :tb303
+                play bass_pattern_f.look, cutoff: 78, release: 0.45, res: 0.8, amp: 0.7
+                
+                kick_amp = n == 0 ? 0.85 : 0.75
+                sample :bd_haus, amp: kick_amp
+                sample :hat_psych, amp: 0.4
+                sleep 0.125
+                sample :hat_psych, amp: 0.3
+                sleep 0.125
+                sample :hat_psych, amp: 0.35
+                sleep 0.125
+                sample :hat_psych, amp: 0.25
+                sleep 0.125
+              end
+            end
+          end
+        end
+      end
+    end
+    
+    # Final transition - Rich sustained chord
+    use_synth :fm
+    play :f2, cutoff: 90, release: 12, divisor: 4, depth: 20, amp: 0.6
+    use_synth :prophet
+    play_chord chord(:f3, :major7), cutoff: 95, release: 12, amp: 0.6
+    use_synth :supersaw
+    play_chord chord(:f4, :major), cutoff: 100, release: 12, amp: 0.5
+    use_synth :subpulse
+    play :f2, cutoff: 68, release: 12, amp: 0.6
+    4.times do
+      sample :bd_haus, amp: 0.7
+      sample :elec_cymbal, amp: 0.4
+      sleep 1
+      sample :elec_hi_snare, amp: 0.5
+      sleep 1
+    end
+    
+  end
+end

--- a/docs/sonic-pi/20260430-073742/Smooth Croon.rb
+++ b/docs/sonic-pi/20260430-073742/Smooth Croon.rb
@@ -1,0 +1,345 @@
+# Smooth Croon
+# Style: Jazz
+# Mood: Smooth
+
+use_debug false
+use_bpm 85
+
+with_fx :level, amp: 1.2 do
+  with_fx :compressor, threshold: 0.4, clamp_time: 0.01, relax_time: 0.1, slope_above: 0.5 do
+
+    # Section 1: Smooth opening with sine lead, warm organ harmony, light percussion, sustained bass
+    2.times do
+      # Drone foundation
+      use_synth :prophet
+      play :f2, release: 16, cutoff: 85, amp: 0.4
+      
+      in_thread do
+        # Harmony: Warm organ pad with major7 chords
+        with_fx :reverb, room: 0.35, mix: 0.35 do
+          use_synth :organ_tonewheel
+          play_chord chord(:f3, :major7), cutoff: 85, release: 16, amp: 0.5
+          
+          4.times do
+            use_synth :rhodey
+            play_chord chord(:f3, :major7), cutoff: 90, release: 1.5, amp: 0.6
+            sleep 2
+            play_chord chord(:g3, :minor7), cutoff: 88, release: 1.5, amp: 0.6
+            sleep 2
+          end
+        end
+      end
+      
+      in_thread do
+        # Bass: Sustained root notes foundation
+        use_synth :bass_foundation
+        play :f2, cutoff: 70, release: 8, amp: 0.7
+        sleep 4
+        play :c2, cutoff: 68, release: 4, amp: 0.65
+        sleep 2
+        play :f2, cutoff: 72, release: 2, amp: 0.6
+        sleep 2
+      end
+      
+      in_thread do
+        # Percussion: Light, sparse jazz groove
+        2.times do
+          sample :drum_bass_soft, amp: 0.6
+          sample :drum_cymbal_soft, amp: 0.35, rate: 0.95
+          sleep 0.75
+          sample :hat_tap, amp: 0.25
+          sleep 0.25
+          
+          sample :drum_cymbal_soft, amp: 0.3, rate: 0.95
+          sleep 0.5
+          sample :drum_snare_soft, amp: 0.55, rate: 1.1
+          sample :drum_cymbal_soft, amp: 0.35, rate: 0.95
+          sleep 0.5
+          
+          sample :drum_cymbal_soft, amp: 0.3, rate: 0.95
+          sleep 0.75
+          sample :hat_tap, amp: 0.25
+          sleep 0.25
+          
+          sample :drum_cymbal_soft, amp: 0.32, rate: 0.95
+          sleep 0.5
+          sample :drum_snare_soft, amp: 0.6, rate: 1.1
+          sample :drum_cymbal_soft, amp: 0.35, rate: 0.95
+          sample :hat_tap, amp: 0.2 if one_in(3)
+          sleep 0.5
+        end
+      end
+      
+      # Melody: Smooth sine lead
+      with_fx :reverb, room: 0.25, mix: 0.3 do
+        use_synth :sine
+        melody_notes = (ring :f4, :a4, :c5, :f5, :e5, :c5, :a4, :g4)
+        sleep_times = (ring 0.75, 0.25, 0.5, 0.5, 0.75, 0.25, 1, 1)
+        
+        8.times do
+          play melody_notes.tick, release: 0.3, cutoff: rrand(90, 110), amp: 0.9
+          sleep sleep_times.look
+        end
+      end
+    end
+    
+    # Transition drone
+    use_synth :fm
+    play :f2, release: 10, cutoff: 88, divisor: 4, depth: 12, amp: 0.5
+    in_thread do
+      use_synth :organ_tonewheel
+      play_chord chord(:c3, :dom7), cutoff: 82, release: 8, amp: 0.55
+    end
+    in_thread do
+      use_synth :fm
+      play :f1, cutoff: 65, release: 4, divisor: 2, depth: 8, amp: 0.6
+    end
+    in_thread do
+      2.times do
+        sample :drum_cymbal_soft, amp: 0.25, rate: 0.9
+        sleep 1
+        sample :hat_tap, amp: 0.2
+        sleep 1
+      end
+    end
+    sleep 4
+    
+    # Section 2: Rhodey warmth, piano harmony, walking bass, active hi-hat
+    3.times do
+      # Sustained pad underneath
+      use_synth :hollow
+      play :f3, release: 12, cutoff: 92, amp: 0.3
+      
+      in_thread do
+        # Harmony: Piano voicings with ii-V-I progression
+        use_synth :organ_tonewheel
+        play_chord chord(:f3, :major7), cutoff: 88, release: 12, amp: 0.5
+        
+        use_synth :piano
+        chords_prog = [chord(:g3, :minor7), chord(:c3, :dom7), chord(:f3, :major7), chord(:d3, :minor7)]
+        
+        4.times do |i|
+          play_chord chords_prog[i], cutoff: (line 85, 105, steps: 4).look, release: 1.8, amp: 0.65
+          sleep 2
+        end
+      end
+      
+      in_thread do
+        # Bass: Walking bass with chromatic approaches
+        with_fx :lpf, cutoff: 75, mix: 0.3 do
+          use_synth :bass_foundation
+          walking_bass = (ring :f2, :a2, :c3, :bf2, :a2, :g2, :e2, :f2)
+          releases = (ring 0.6, 0.5, 0.5, 0.6, 0.5, 0.5, 0.7, 0.8)
+          
+          8.times do
+            play walking_bass.tick, cutoff: (line 70, 80, steps: 8).tick, release: releases.look, amp: 0.65
+            sleep 1
+          end
+        end
+      end
+      
+      in_thread do
+        # Percussion: Building groove with more hi-hat activity
+        2.times do
+          sample :drum_bass_soft, amp: 0.65
+          sample :drum_cymbal_soft, amp: 0.38, rate: 0.95
+          sample :hat_tap, amp: 0.3
+          sleep 0.5
+          sample :hat_tap, amp: 0.25
+          sleep 0.25
+          sample :drum_cymbal_soft, amp: 0.3, rate: 0.95
+          sleep 0.25
+          
+          sample :drum_snare_soft, amp: 0.6, rate: 1.1
+          sample :drum_cymbal_soft, amp: 0.38, rate: 0.95
+          sample :hat_tap, amp: 0.3
+          sleep 0.5
+          sample :hat_tap, amp: 0.28
+          sleep 0.5
+          
+          sample :drum_bass_soft, amp: 0.5
+          sample :drum_cymbal_soft, amp: 0.35, rate: 0.95
+          sample :hat_tap, amp: 0.3
+          sleep 0.5
+          sample :hat_tap, amp: 0.25
+          sleep 0.25
+          sample :drum_cymbal_soft, amp: 0.3, rate: 0.95
+          sample :hat_tap, amp: 0.2
+          sleep 0.25
+          
+          sample :drum_snare_soft, amp: 0.65, rate: 1.1
+          sample :drum_cymbal_soft, amp: 0.38, rate: 0.95
+          sample :hat_tap, amp: 0.32
+          sleep 0.5
+          sample :hat_tap, amp: 0.25
+          sample :drum_cymbal_soft, amp: 0.28, rate: 0.95 if one_in(2)
+          sleep 0.5
+        end
+      end
+      
+      # Melody: Rhodey adds warmth
+      with_fx :lpf, cutoff: 105, mix: 0.3 do
+        with_fx :reverb, room: 0.28, mix: 0.25 do
+          use_synth :rhodey
+          jazz_phrase = (ring :a4, :c5, :d5, :c5, :bf4, :a4, :g4, :f4)
+          timings = (ring 0.5, 0.5, 0.75, 0.25, 0.5, 0.5, 1, 1)
+          
+          8.times do
+            play jazz_phrase.tick, release: 0.4, cutoff: (line 85, 115, steps: 8).tick, amp: 0.95
+            sleep timings.look
+          end
+        end
+      end
+    end
+    
+    # Transition drone
+    use_synth :prophet
+    play :f2, release: 8, cutoff: 90, amp: 0.6
+    in_thread do
+      use_synth :rhodey
+      play_chord chord(:f3, :major7), cutoff: 90, release: 8, amp: 0.6
+    end
+    in_thread do
+      use_synth :bass_foundation
+      play :f2, cutoff: 68, release: 4, amp: 0.7
+    end
+    in_thread do
+      2.times do
+        sample :drum_cymbal_soft, amp: 0.3, rate: 0.9
+        sleep 1
+        sample :drum_snare_soft, amp: 0.45, rate: 1.1
+        sleep 1
+      end
+    end
+    sleep 4
+    
+    # Section 3: Piano finale with rich harmony, deep bass slides, full jazz groove
+    2.times do
+      # Deep drone foundation
+      use_synth :fm
+      play :f2, release: 14, cutoff: 87, divisor: 5, depth: 18, amp: 0.45
+      
+      in_thread do
+        # Harmony: Rich piano and rhodey blend with extensions
+        use_synth :organ_tonewheel
+        play_chord chord(:f2, :major7), cutoff: 80, release: 14, amp: 0.5
+        
+        8.times do |n|
+          if n % 2 == 0
+            use_synth :piano
+            play_chord chord(:f3, :maj9), cutoff: rrand(90, 110), release: 1.5, amp: 0.7
+          else
+            use_synth :rhodey
+            play_chord chord(:c3, :dom7), cutoff: rrand(85, 105), release: 1.5, amp: 0.65
+          end
+          sleep 1
+        end
+      end
+      
+      in_thread do
+        # Bass: Deep foundation with slides
+        use_synth :fm
+        play :f1, cutoff: 65, release: 7, divisor: 3, depth: 10, amp: 0.65
+        sleep 2
+        
+        use_synth :bass_foundation
+        play :g2, cutoff: 72, release: 0.6, amp: 0.6
+        sleep 1
+        play :a2, cutoff: 74, release: 0.6, amp: 0.6
+        sleep 1
+        play :bf2, cutoff: 76, release: 0.8, amp: 0.65
+        sleep 1
+        play :c3, cutoff: 75, release: 1.5, amp: 0.7
+        sleep 1.5
+        play :bf2, cutoff: 72, release: 0.7, amp: 0.6
+        sleep 0.5
+        play :a2, cutoff: 70, release: 0.5, amp: 0.6
+        sleep 0.5
+        play :g2, cutoff: 68, release: 0.5, amp: 0.6
+        sleep 0.5
+        play :f2, cutoff: 70, release: 1, amp: 0.7
+        sleep 1
+      end
+      
+      in_thread do
+        # Percussion: Full jazz groove for piano finale
+        with_fx :reverb, room: 0.25, mix: 0.25 do
+          2.times do
+            sample :drum_bass_soft, amp: 0.7
+            sample :drum_cymbal_soft, amp: 0.4, rate: 0.95
+            sample :hat_tap, amp: 0.35
+            sleep 0.5
+            sample :hat_tap, amp: 0.28
+            sleep 0.25
+            sample :drum_cymbal_soft, amp: 0.32, rate: 0.95
+            sample :hat_tap, amp: 0.25
+            sleep 0.25
+            
+            sample :drum_snare_soft, amp: 0.65, rate: 1.1
+            sample :drum_cymbal_soft, amp: 0.4, rate: 0.95
+            sample :hat_tap, amp: 0.35
+            sleep 0.5
+            sample :hat_tap, amp: 0.3
+            sleep 0.25
+            sample :drum_cymbal_soft, amp: 0.3, rate: 0.95
+            sleep 0.25
+            
+            sample :drum_bass_soft, amp: 0.6
+            sample :drum_cymbal_soft, amp: 0.38, rate: 0.95
+            sample :hat_tap, amp: 0.35
+            sleep 0.5
+            sample :hat_tap, amp: 0.28
+            sample :drum_bass_soft, amp: 0.45 if one_in(3)
+            sleep 0.25
+            sample :drum_cymbal_soft, amp: 0.32, rate: 0.95
+            sample :hat_tap, amp: 0.25
+            sleep 0.25
+            
+            sample :drum_snare_soft, amp: 0.7, rate: 1.1
+            sample :drum_cymbal_soft, amp: 0.4, rate: 0.95
+            sample :hat_tap, amp: 0.35
+            sleep 0.5
+            sample :hat_tap, amp: 0.3
+            sleep 0.25
+            sample :drum_cymbal_soft, amp: 0.35, rate: 0.95
+            sample :hat_tap, amp: 0.28
+            sleep 0.25
+          end
+        end
+      end
+      
+      # Melody: Piano finale with embellishments
+      use_synth :piano
+      final_melody = (ring :f4, :g4, :a4, :bf4, :c5, :d5, :c5, :bf4, :a4, :g4, :f4, :e4, :f4, :a4, :c5, :f5)
+      note_lengths = (ring 0.5, 0.25, 0.25, 0.5, 0.5, 0.75, 0.25, 0.5, 0.25, 0.25, 0.5, 0.5, 0.75, 0.25, 1, 1)
+      
+      16.times do
+        play final_melody.tick, release: 0.35, cutoff: rrand(95, 120), amp: 1.0
+        sleep note_lengths.look
+      end
+    end
+    
+    # Ending drone - fades into silence
+    use_synth :prophet
+    play :f2, release: 12, cutoff: 80, amp: 0.5
+    in_thread do
+      use_synth :organ_tonewheel
+      play_chord chord(:f2, :major7), cutoff: 75, release: 12, amp: 0.5
+    end
+    in_thread do
+      use_synth :bass_foundation
+      play :f1, cutoff: 65, release: 12, amp: 0.7
+    end
+    in_thread do
+      4.times do |i|
+        fade_amp = (line 0.35, 0.15, steps: 4).tick
+        sample :drum_cymbal_soft, amp: fade_amp, rate: 0.9
+        sleep 1
+        sample :hat_tap, amp: fade_amp * 0.6
+        sleep 1
+      end
+    end
+    sleep 8
+    
+  end
+end

--- a/docs/sonic-pi/20260430-080444/Electronic Classical Fusion.rb
+++ b/docs/sonic-pi/20260430-080444/Electronic Classical Fusion.rb
@@ -1,0 +1,255 @@
+# Electronic Classical Fusion
+# Style: Electronic Classical Fusion
+# Mood: Ethereal and atmospheric
+
+use_debug false
+use_bpm 120
+
+with_fx :level, amp: 1.2 do
+  with_fx :compressor, threshold: 0.4, clamp_time: 0.01, relax_time: 0.1, slope_above: 0.5 do
+    
+    # Section 1: Ethereal opening with sparse percussion and foundation harmony
+    2.times do
+      in_thread do
+        use_synth :prophet
+        play :c2, release: 16, cutoff: 85, amp: 0.5
+      end
+      
+      in_thread do
+        with_fx :reverb, room: 0.35, mix: 0.3 do
+          use_synth :dark_ambience
+          play_chord chord(:c2, :major), cutoff: 85, release: 16, amp: 0.4
+        end
+      end
+      
+      in_thread do
+        use_synth :bass_foundation
+        play :c2, cutoff: 70, release: 8, amp: 0.6
+        sleep 8
+        use_synth :subpulse
+        bass_pattern = (ring :c2, :c2, :g2, :g2)
+        4.times do
+          play bass_pattern.tick, cutoff: 75, release: 1.8, amp: 0.55
+          sleep 2
+        end
+      end
+      
+      in_thread do
+        with_fx :reverb, room: 0.25, mix: 0.25 do
+          melody_notes = (ring :c4, :e4, :g4, :a4, :g4, :e4, :d4, :c4)
+          cutoffs = (line 90, 115, steps: 8)
+          use_synth :prophet
+          8.times do
+            play melody_notes.tick, release: 0.8, cutoff: cutoffs.look, amp: 0.9
+            sleep 1
+          end
+        end
+      end
+      
+      in_thread do
+        with_fx :reverb, room: 0.35, mix: 0.3 do
+          use_synth :sine
+          chords_section1 = (knit chord(:c3, :major), 4, chord(:a3, :minor), 2, chord(:f3, :major), 2)
+          8.times do
+            play_chord chords_section1.tick, cutoff: (line 88, 105, steps: 8).look, release: 1.5, amp: 0.4
+            sleep 2
+          end
+        end
+      end
+      
+      in_thread do
+        8.times do |b|
+          sample :bd_haus, amp: (b == 0) ? 0.6 : 0.5
+          sample :drum_cymbal_closed, amp: 0.25 if b % 2 == 1
+          sleep 1
+        end
+        4.times do
+          sample :bd_haus, amp: 0.5
+          sample :hat_psych, amp: 0.2
+          sleep 0.5
+          sample :elec_snare, amp: 0.4
+          sample :drum_cymbal_closed, amp: 0.25
+          sleep 0.5
+        end
+      end
+      
+      in_thread do
+        sleep 8
+        use_synth :prophet
+        4.times do
+          play (scale :c4, :major).choose, release: 0.4, cutoff: rrand(95, 110), amp: 0.85
+          sleep 0.5
+          play (scale :c5, :major).choose, release: 0.3, cutoff: rrand(100, 120), amp: 0.9
+          sleep 0.5
+        end
+      end
+      
+      sleep 16
+    end
+    
+    # Transition drone between Section 1 and Section 2
+    use_synth :hollow
+    play :g2, cutoff: 88, release: 10, amp: 0.6
+    sleep 4
+    
+    # Section 2: Building intensity with layered harmonies and tighter percussion
+    3.times do
+      in_thread do
+        use_synth :fm
+        play :c2, release: 12, cutoff: 90, divisor: 8, depth: 15, amp: 0.4
+      end
+      
+      in_thread do
+        use_synth :fm
+        play_chord chord(:c2, :major), cutoff: 92, release: 12, divisor: 8, depth: 10, amp: 0.35
+      end
+      
+      in_thread do
+        with_fx :lpf, cutoff: 85, mix: 0.25 do
+          use_synth :tb303
+          walking_bass = (ring :c2, :e2, :g2, :e2, :d2, :b1, :g1, :c2)
+          8.times do
+            play walking_bass.tick, cutoff: 80, release: 0.8, res: 0.7, amp: 0.6
+            sleep 1
+          end
+        end
+      end
+      
+      in_thread do
+        with_fx :lpf, cutoff: 110, mix: 0.25 do
+          use_synth :supersaw
+          arpeggios = (ring :e4, :g4, :c5, :e5, :d5, :b4, :g4, :e4)
+          8.times do
+            play arpeggios.tick, release: 0.5, cutoff: (line 100, 130, steps: 8).look, amp: 0.95
+            sleep 0.5
+            play arpeggios.look - 12, release: 0.2, cutoff: 85, amp: 0.8
+            sleep 0.5
+          end
+        end
+      end
+      
+      in_thread do
+        use_synth :sine
+        progression = (knit chord(:c3, :major), 2, chord(:g3, :major), 2, chord(:a3, :minor), 2, chord(:f3, :major), 2)
+        8.times do
+          chord_notes = progression.tick
+          chord_notes.each do |note|
+            play note, cutoff: (line 95, 120, steps: 8).look, release: 0.3, amp: 0.45
+            sleep 0.25
+          end
+          sleep 0.5
+        end
+      end
+      
+      in_thread do
+        with_fx :reverb, room: 0.25, mix: 0.2 do
+          8.times do |b|
+            sample :bd_haus, amp: (b == 0) ? 0.7 : 0.6 if spread(3, 8)[b]
+            sample :drum_cymbal_closed, amp: 0.3
+            sleep 0.5
+            sample :elec_snare, amp: 0.5 if b % 2 == 1
+            sample :hat_psych, amp: 0.25 if one_in(3)
+            sample :drum_cymbal_closed, amp: 0.25
+            sleep 0.5
+          end
+        end
+      end
+      
+      sleep 16
+    end
+    
+    # Transition drone between Section 2 and Section 3
+    use_synth :prophet
+    play :c2, cutoff: 92, release: 12, amp: 0.6
+    sleep 4
+    
+    # Section 3: Ethereal resolution with slower pacing and refined dynamics
+    2.times do
+      in_thread do
+        use_synth :prophet
+        play :c2, release: 14, cutoff: 80, amp: 0.45
+      end
+      
+      in_thread do
+        with_fx :reverb, room: 0.4, mix: 0.35 do
+          use_synth :dark_ambience
+          play_chord chord(:c2, :major), cutoff: 82, release: 14, amp: 0.5
+        end
+      end
+      
+      in_thread do
+        use_synth :bass_foundation
+        play :c2, cutoff: 65, release: 16, amp: 0.65
+        sleep 8
+        use_synth :subpulse
+        resolution_bass = (knit :c2, 4, :f2, 2, :g2, 2)
+        8.times do
+          play resolution_bass.tick, cutoff: 70, release: 1.5, amp: 0.5
+          sleep 1
+        end
+      end
+      
+      in_thread do
+        with_fx :reverb, room: 0.3, mix: 0.3 do
+          with_fx :echo, phase: 1, decay: 1.5, mix: 0.2 do
+            use_synth :hollow
+            final_melody = (knit :c4, 2, :e4, 2, :g4, 2, :c5, 2, :a4, 2, :f4, 2, :d4, 2, :c4, 2)
+            16.times do
+              play final_melody.tick, release: 1.2, cutoff: rrand(88, 105), amp: 0.9
+              sleep 1
+            end
+          end
+        end
+      end
+      
+      in_thread do
+        with_fx :reverb, room: 0.4, mix: 0.35 do
+          use_synth :sine
+          final_chords = (knit chord(:c3, :major), 4, chord(:f3, :major), 4, chord(:g3, :major), 4, chord(:c3, :major), 4)
+          16.times do
+            play_chord final_chords.tick, cutoff: rrand(85, 100), release: 1.8, amp: 0.4
+            sleep 2
+          end
+        end
+      end
+      
+      in_thread do
+        16.times do |b|
+          sample :bd_haus, amp: (b == 0) ? 0.65 : 0.55 if b % 2 == 0
+          sample :drum_cymbal_closed, amp: 0.3 if b % 2 == 1
+          sample :hat_psych, amp: 0.23 if b % 4 == 3
+          sleep 1
+        end
+      end
+      
+      sleep 32
+    end
+    
+    # Final resolution with sparse percussion fade
+    in_thread do
+      use_synth :prophet
+      play_chord chord(:c3, :major), release: 8, cutoff: 85, amp: 0.7
+    end
+    
+    in_thread do
+      use_synth :dark_ambience
+      play_chord chord(:c2, :major), cutoff: 80, release: 8, amp: 0.6
+    end
+    
+    in_thread do
+      use_synth :bass_foundation
+      play :c2, cutoff: 65, release: 8, amp: 0.6
+    end
+    
+    in_thread do
+      8.times do |b|
+        sample :bd_haus, amp: 0.4 if b % 4 == 0
+        sample :drum_cymbal_closed, amp: 0.2
+        sleep 1
+      end
+    end
+    
+    sleep 8
+    
+  end
+end

--- a/src/main/java/com/embabel/demo/agent/SonicPiAgent.java
+++ b/src/main/java/com/embabel/demo/agent/SonicPiAgent.java
@@ -8,6 +8,7 @@ import com.embabel.agent.api.common.OperationContext;
 import com.embabel.agent.domain.io.UserInput;
 import com.embabel.common.ai.model.LlmOptions;
 import com.embabel.demo.model.sonicpi.SonicPiMetadata;
+import com.embabel.demo.model.sonicpi.SonicPiScriptWithBass;
 import com.embabel.demo.model.sonicpi.SonicPiScriptWithHarmony;
 import com.embabel.demo.model.sonicpi.SonicPiScriptWithMelody;
 import com.embabel.demo.model.sonicpi.SonicPiScriptWithPercussion;
@@ -115,6 +116,21 @@ public class SonicPiAgent {
                         "percussionSamples", String.join(", ", sonicPiMetadata.percussionSamples())));
     }
 
+    @Action
+    public SonicPiScriptWithBass addBass(
+            SonicPiScriptWithMelody sonicPiScriptWithMelody, SonicPiMetadata sonicPiMetadata, OperationContext context) {
+        LOG.info("Adding bass track to {}", sonicPiScriptWithMelody);
+        return context.ai()
+                .withLlm(LlmOptions.withAutoLlm().withTemperature(1.0))
+                .withPromptContributor(sonicPiPromptContributor)
+                .withPromptContributor(() -> sonicPiExamplesContributor.contributionFor(sonicPiMetadata))
+                .withTemplate("sonicpi/add-bass.jinja")
+                .createObject(SonicPiScriptWithBass.class, Map.of(
+                        "melodyScriptContent", sonicPiScriptWithMelody.scriptContent(),
+                        "bassDescription", sonicPiMetadata.bassDescription(),
+                        "bassInstruments", String.join(", ", sonicPiMetadata.bassInstruments())));
+    }
+
     @AchievesGoal(
             description = "Sonic Pi code has been generated based on user input",
             export = @Export(remote = true, name = "sonicPiCode", startingInputTypes = {UserInput.class}))
@@ -124,12 +140,14 @@ public class SonicPiAgent {
             SonicPiScriptWithMelody sonicPiScriptWithMelody,
             SonicPiScriptWithHarmony sonicPiScriptWithHarmony,
             SonicPiScriptWithPercussion sonicPiScriptWithPercussion,
+            SonicPiScriptWithBass sonicPiScriptWithBass,
             OperationContext context) {
 
         LOG.info("Combining all Sonic Pi scripts into one final script from the following parts:");
         LOG.info("{}", sonicPiScriptWithMelody.scriptContent());
         LOG.info("{}", sonicPiScriptWithHarmony.scriptContent());
         LOG.info("{}", sonicPiScriptWithPercussion.scriptContent());
+        LOG.info("{}", sonicPiScriptWithBass.scriptContent());
 
         var scriptContent = context.ai()
                 .withLlm(LlmOptions.withAutoLlm().withTemperature(1.0).withTimeout(Duration.ofSeconds(120)))
@@ -139,7 +157,8 @@ public class SonicPiAgent {
                 .createObject(String.class, Map.of(
                         "melodyScriptContent", sonicPiScriptWithMelody.scriptContent(),
                         "harmonyScriptContent", sonicPiScriptWithHarmony.scriptContent(),
-                        "percussionScriptContent", sonicPiScriptWithPercussion.scriptContent()));
+                        "percussionScriptContent", sonicPiScriptWithPercussion.scriptContent(),
+                        "bassScriptContent", sonicPiScriptWithBass.scriptContent()));
 
         var filename = "sonic_pi_script_%s.rb".formatted(System.currentTimeMillis());
         writeFile(filename, scriptContent);

--- a/src/main/java/com/embabel/demo/model/sonicpi/SonicPiMetadata.java
+++ b/src/main/java/com/embabel/demo/model/sonicpi/SonicPiMetadata.java
@@ -49,6 +49,9 @@ public record SonicPiMetadata(
         @NotEmpty(message = "At least one sample must be specified.")
         List<String> percussionSamples,
 
+        @NotEmpty(message = "At least one instrument must be specified.")
+        List<String> bassInstruments,
+
         @NotBlank(message = "Must not be blank.")
         String style,
 
@@ -59,5 +62,8 @@ public record SonicPiMetadata(
         String harmonyDescription,
 
         @NotBlank(message = "Must not be blank.")
-        String percussionDescription) {
+        String percussionDescription,
+
+        @NotBlank(message = "Must not be blank.")
+        String bassDescription) {
 }

--- a/src/main/java/com/embabel/demo/model/sonicpi/SonicPiScriptWithBass.java
+++ b/src/main/java/com/embabel/demo/model/sonicpi/SonicPiScriptWithBass.java
@@ -1,0 +1,13 @@
+package com.embabel.demo.model.sonicpi;
+
+import jakarta.annotation.Nonnull;
+
+/**
+ * Holds the generated Sonic Pi Ruby code for the bass track. Produced by the {@code addBass}
+ * action, which writes low-register bass lines that provide the harmonic and rhythmic foundation
+ * underneath the melody. Fed into the {@code combineAllSonicPiScripts} action to create the
+ * final arrangement.
+ */
+public record SonicPiScriptWithBass(
+        @Nonnull String scriptContent) {
+}

--- a/src/main/resources/prompts/sonicpi/add-bass.jinja
+++ b/src/main/resources/prompts/sonicpi/add-bass.jinja
@@ -1,0 +1,83 @@
+Write a bass track for this existing Sonic Pi melody script:
+<melodyScriptContent>
+{{ melodyScriptContent }}
+</melodyScriptContent>
+
+Add a bass line as per this description:
+<bassDescription>
+{{ bassDescription }}
+</bassDescription>
+
+Use the following instruments:
+<bassInstruments>
+{{ bassInstruments }}
+</bassInstruments>
+
+The bass provides the LOW-REGISTER FOUNDATION — root notes and fifths that anchor the harmony.
+Use LOW OCTAVES (`:c2`, `:e2`, `:g2` range — octave 1-3) to sit well below the melody and harmony.
+Think BASS GUITAR or ELECTRONIC SUB BASS — not kick drums, not chords, not pads.
+
+Ensure the code is ready to run in Sonic Pi without any modifications.
+Provide a comment at the top of the script content with the song title.
+Do not include the melody again; only provide the bass part in the scriptContent.
+Be aware of the existing instruments used in the melody to avoid clashes.
+Be aware of the key changes in the melody when composing the bass.
+
+The bass must sit BELOW the melody in the mix — it provides audible low-end weight without competing.
+Use amplitudes in the range amp 0.5-0.8 for bass parts.
+Never let any bass element exceed amp: 0.8.
+
+Use `cutoff: 60-90` to keep the bass warm and round without competing with melody brightness.
+
+FX rules — bass needs to be clean and tight:
+- `:lpf` with `cutoff: 60-90` to keep it warm.
+- `:compressor` sparingly to even out dynamics.
+- Avoid `:reverb` and `:echo` on bass — they muddy the low end.
+- Always set a `mix:` parameter on every FX that supports it.
+- Place `with_fx` INSIDE `N.times do` blocks, wrapping the inner content.
+- Use FX on at most 1 bass section. Bass needs clarity — too much FX creates mud.
+
+Synth parameter rules — always set `cutoff:` and `release:` on every `play` call:
+- Use `cutoff:` in the 60-90 range for warm, round bass.
+- Use long `release: 4-8` for droning bass notes that sustain under sections.
+- Use shorter `release: 0.3-1` for rhythmic walking bass lines.
+- Each bass section should include at least one long sustained root note.
+
+Notes should be HELD FOR LONGER DURATIONS than the melody:
+- `release: 2-8` for sustained bass notes.
+- `release: 0.5-1` for walking bass patterns.
+
+Example of effective bass sections:
+```
+# Bass section 1 — sustained root notes
+2.times do
+  use_synth :bass_foundation
+  play :c2, cutoff: 70, release: 4, amp: 0.7
+  sleep 4
+  play :g2, cutoff: 75, release: 4, amp: 0.6
+  sleep 4
+end
+
+# Bass section 2 — walking bass line
+2.times do
+  use_synth :bass_highend
+  bass_notes = (ring :c2, :e2, :g2, :f2)
+  8.times do
+    play bass_notes.tick, cutoff: 80, release: 0.5, amp: 0.65
+    sleep 1
+  end
+end
+```
+
+Idiomatic patterns for bass:
+- `ring()` for cycling root notes: `play (ring :c2, :f2, :g2).tick, cutoff: 70, release: 2`.
+- `knit()` for weighted note choices: `notes = knit(:c2, 4, :g2, 2, :f2, 2)`.
+- `scale()` for walking bass: `play scale(:c2, :major).tick, release: 0.5`.
+
+Script structure rules:
+- NEVER use `live_loop`. Structure the bass as 2-3 sequential `N.times do` sections.
+- Each section should repeat 2-4 times before progressing to the next.
+- Match the number and pacing of sections to the melody — the bass sections should align with the melody sections.
+- Evolve the bass across sections — move through chord roots, change rhythmic density.
+- Use inner `.times do` loops within sections to repeat patterns — do not write out every bar individually.
+- Keep the script concise.

--- a/src/main/resources/prompts/sonicpi/combine-all-parts.jinja
+++ b/src/main/resources/prompts/sonicpi/combine-all-parts.jinja
@@ -13,9 +13,13 @@ Return ONLY the Sonic Pi Ruby script code. No explanation, no markdown fences, n
 {{ percussionScriptContent }}
 </percussionScriptContent>
 
+<bassScriptContent>
+{{ bassScriptContent }}
+</bassScriptContent>
+
 Song structure — use sequential `N.times do` sections, NEVER `live_loop`:
-- Weave melody, harmony, and percussion together into integrated sequential sections.
-- Each section is a `N.times do` block where melody, harmony, and percussion all play together within the block.
+- Weave melody, harmony, bass, and percussion together into integrated sequential sections.
+- Each section is a `N.times do` block where melody, harmony, bass, and percussion all play together within the block.
 - The song should have 3-5 sections that progress and evolve over time.
 - Each section repeats 2-4 times before moving to the next.
 - There must NEVER be silence between sections. Always add a transition drone between sections: a long sustained synth note (e.g., `use_synth :prophet; play 28, cutoff: 90, release: 8, amp: 0.6; sleep 4`) that bridges one section into the next. The drone's release should be long enough to overlap with the start of the next section.
@@ -25,6 +29,7 @@ Song structure — use sequential `N.times do` sections, NEVER `live_loop`:
 Mix balance — the melody is the LEAD VOICE and must be the most prominent element:
 - Melody: amp 0.8-1.0 — loudest, clearly audible as the part listeners can hum along to.
 - Harmony: amp 0.5-0.8 — sits below the melody, providing audible chord support.
+- Bass: amp 0.5-0.8 — low-end foundation, uses cutoff 60-90 (low) while harmony uses cutoff 80-130 (mid-high).
 - Percussion: amp 0.4-0.7 for kicks, lower for other hits — provides rhythmic foundation without overpowering.
 If the input parts have amplitudes that violate this balance, adjust them so the melody is always on top.
 

--- a/src/main/resources/prompts/sonicpi/to-meta-data.jinja
+++ b/src/main/resources/prompts/sonicpi/to-meta-data.jinja
@@ -4,6 +4,7 @@ The user input is:
 {{ userInput }}
 </userInput>
 Extract the melody description as a string.
+Extract the bass description as a string describing the bass style and feel.
 
 Key must be one of:
 <keys>


### PR DESCRIPTION
## Summary
- Add dedicated bass track that runs in **parallel** with harmony and percussion in the SonicPiAgent pipeline
- Bass provides low-register foundation (octave 1-3, cutoff 60-90) using instruments like `bass_foundation` and `bass_highend`
- New `addBass` action follows the same pattern as `addHarmony`/`addPercussion`: takes melody + metadata, uses Jinja template with prompt contributors

## Changes
| File | Change |
|------|--------|
| `SonicPiMetadata.java` | Add `bassInstruments` (List) and `bassDescription` (String) fields |
| `SonicPiScriptWithBass.java` | New model record with `@Nonnull String scriptContent` |
| `to-meta-data.jinja` | Extract bass metadata from user input |
| `add-bass.jinja` | New prompt template for bass track generation |
| `SonicPiAgent.java` | Add `addBass` action; update `combineAllSonicPiScripts` to include bass |
| `combine-all-parts.jinja` | Add `bassScriptContent` variable and mix-balance rules for bass |

## Pipeline
```
                           ┌─ addHarmony ────┐
UserInput → metadata → melody ─┼─ addPercussion ─┼─ combineAll → final script
                           └─ addBass ───────┘
```

## Test plan
- [ ] Build compiles successfully (`mvn compile` passes)
- [ ] Run E2E tests to verify bass track appears in generated scripts
- [ ] Play generated script in Sonic Pi — bass is audible as a distinct low-frequency layer

Closes #22

🤖 Generated with [Claude Code](https://claude.com/claude-code)