### PR TITLE
Fix LLM example-selection JSON parse failure

### DIFF
--- a/docs/sonic-pi/20260430-081636/Electronic Classical Fusion.rb
+++ b/docs/sonic-pi/20260430-081636/Electronic Classical Fusion.rb
@@ -1,0 +1,257 @@
+# Electric Symphony
+# Electronic / Dramatic / 128 BPM / 4/4 Time
+# Key: Am → C
+
+use_debug false
+use_bpm 128
+
+with_fx :level, amp: 1.2 do
+  with_fx :compressor, threshold: 0.4, clamp_time: 0.01, relax_time: 0.1, slope_above: 0.5 do
+    
+    # Section 1: Dark atmospheric opening in Am
+    # Melody: saw lead with drone foundation
+    # Harmony: dark_ambience pads with hollow chords
+    # Bass: sustained foundation with subtle tb303 pulse
+    # Percussion: sparse, building tension
+    3.times do
+      in_thread do
+        use_synth :prophet
+        play :a2, release: 12, cutoff: 85, amp: 0.5
+        
+        with_fx :lpf, cutoff: 100 do
+          with_fx :reverb, room: 0.25, mix: 0.3 do
+            use_synth :saw
+            melody_notes = (ring :a3, :c4, :e4, :a4, :e4, :c4, :d4, :e4)
+            16.times do
+              play melody_notes.tick, cutoff: rrand(90, 110), release: 0.2, amp: 0.9
+              sleep 0.25
+            end
+          end
+        end
+      end
+      
+      in_thread do
+        with_fx :reverb, room: 0.3, mix: 0.35 do
+          use_synth :dark_ambience
+          play_chord chord(:a2, :minor), cutoff: 85, release: 12, amp: 0.6
+          
+          use_synth :hollow
+          chords_progression = [chord(:a3, :minor), chord(:c3, :major), chord(:d3, :minor), chord(:e3, :minor)]
+          4.times do |i|
+            play_chord chords_progression[i], cutoff: (line 80, 100, steps: 4).look, release: 4, amp: 0.5
+            sleep 4
+          end
+        end
+      end
+      
+      in_thread do
+        use_synth :bass_foundation
+        play :a1, cutoff: 65, release: 8, amp: 0.75
+        sleep 2
+        
+        use_synth :tb303
+        bass_pattern = (ring :a2, :a2, :e2, :a2)
+        4.times do
+          play bass_pattern.tick, cutoff: 70, release: 0.8, res: 0.8, amp: 0.6
+          sleep 1
+        end
+        
+        use_synth :bass_foundation
+        play :e2, cutoff: 68, release: 4, amp: 0.7
+        sleep 2
+      end
+      
+      in_thread do
+        4.times do
+          sample :bd_haus, amp: 0.6
+          sleep 0.5
+          sample :elec_tick, amp: 0.3
+          sleep 0.25
+          sample :elec_tick, amp: 0.25
+          sleep 0.25
+          sample :elec_snare, amp: 0.5
+          sleep 0.5
+          sample :hat_psych, amp: 0.35
+          sleep 0.25
+          sample :hat_psych, amp: 0.3
+          sleep 0.25
+        end
+      end
+      
+      sleep 16
+    end
+    
+    # Transition drone - bridges to next section
+    use_synth :prophet
+    play :a2, cutoff: 90, release: 8, amp: 0.6
+    sample :drum_cymbal_soft, amp: 0.5, rate: 0.9
+    sleep 4
+    
+    # Section 2: Building intensity with supersaw in Am
+    # Melody: faster rhythmic patterns with supersaw
+    # Harmony: layered pads with voice leading
+    # Bass: walking bass pattern with syncopation
+    # Percussion: faster patterns, more layers
+    3.times do
+      in_thread do
+        use_synth :fm
+        play :a2, release: 10, divisor: 3, depth: 15, cutoff: 80, amp: 0.4
+        
+        use_synth :supersaw
+        melody_pattern = (ring :a4, :gs4, :a4, :c5, :e5, :d5, :c5, :a4)
+        cutoff_line = (line 85, 115, steps: 16)
+        16.times do
+          play melody_pattern.tick, cutoff: cutoff_line.tick, release: 0.15, amp: 0.95
+          sleep 0.25
+        end
+      end
+      
+      in_thread do
+        use_synth :dark_ambience
+        play_chord chord(:a2, :minor7), cutoff: 80, release: 10, amp: 0.55
+        
+        with_fx :lpf, cutoff: 100 do
+          use_synth :prophet
+          harmonic_sequence = [chord(:a3, :minor7), chord(:f3, :major7), chord(:c3, :major), chord(:g3, :dom7)]
+          4.times do |i|
+            play_chord harmonic_sequence[i], cutoff: rrand(85, 105), release: 3.5, amp: 0.6
+            sleep 4
+          end
+        end
+      end
+      
+      in_thread do
+        with_fx :lpf, cutoff: 85 do
+          use_synth :bass_foundation
+          play :a1, cutoff: 68, release: 6, amp: 0.75
+          sleep 1
+          
+          use_synth :tb303
+          syncopated_bass = (ring :a2, :e2, :g2, :a2, :c3, :a2, :g2, :e2)
+          cutoff_vals = (line 72, 88, steps: 8)
+          8.times do
+            play syncopated_bass.tick, cutoff: cutoff_vals.tick, release: 0.5, res: 0.85, amp: 0.65
+            sleep 0.5
+          end
+          
+          use_synth :chipbass
+          play :e2, cutoff: 75, release: 2, amp: 0.6
+          sleep 2
+        end
+      end
+      
+      in_thread do
+        with_fx :hpf, cutoff: 100 do
+          16.times do
+            sample :bd_haus, amp: 0.7
+            sample :hat_psych, amp: 0.4
+            sleep 0.25
+            sample :hat_psych, amp: 0.35
+            sleep 0.25
+            sample :elec_snare, amp: 0.6
+            sample :hat_psych, amp: 0.4
+            sample :elec_tick, amp: 0.4 if one_in(3)
+            sleep 0.25
+            sample :hat_psych, amp: 0.35
+            sleep 0.25
+          end
+        end
+      end
+      
+      sleep 16
+    end
+    
+    # Transition drone with key change preparation
+    use_synth :prophet
+    play :c3, cutoff: 95, release: 10, amp: 0.65
+    sample :drum_cymbal_soft, amp: 0.6, rate: 1.0
+    4.times do
+      sample :elec_tick, amp: 0.5
+      sleep 0.25
+    end
+    sleep 3
+    
+    # Section 3: KEY CHANGE to C major - climactic resolution
+    # Melody: prophet synth for dramatic lead voice
+    # Harmony: full voiced chords with classical voice leading
+    # Bass: powerful root notes with rhythmic accents
+    # Percussion: dense patterns supporting climax
+    4.times do
+      in_thread do
+        use_synth :dsaw
+        play :c2, release: 12, cutoff: 75, amp: 0.45
+        
+        with_fx :reverb, room: 0.3, mix: 0.35 do
+          use_synth :prophet
+          climax_melody = (ring :c4, :e4, :g4, :c5, :g4, :e4, :f4, :g4)
+          cutoff_ramp = (line 95, 125, steps: 16)
+          16.times do
+            play climax_melody.tick, cutoff: cutoff_ramp.tick, release: 0.25, amp: 1.0
+            sleep 0.25
+          end
+        end
+      end
+      
+      in_thread do
+        with_fx :reverb, room: 0.35, mix: 0.4 do
+          use_synth :dark_ambience
+          play_chord chord(:c2, :major), cutoff: 75, release: 14, amp: 0.65
+          
+          use_synth :prophet
+          climax_chords = [chord(:c3, :major), chord(:f3, :major), chord(:g3, :dom7), chord(:c3, :major)]
+          cutoff_sweep = (line 90, 120, steps: 4)
+          4.times do |i|
+            play_chord climax_chords[i], cutoff: cutoff_sweep.tick, release: 3.8, amp: 0.7
+            sleep 4
+          end
+        end
+      end
+      
+      in_thread do
+        use_synth :bass_foundation
+        play :c2, cutoff: 70, release: 8, amp: 0.8
+        sleep 2
+        
+        use_synth :tb303
+        climax_bass = (ring :c2, :g2, :c3, :g2, :f2, :c2, :g2, :c2)
+        cutoff_climb = (line 75, 90, steps: 8)
+        8.times do
+          play climax_bass.tick, cutoff: cutoff_climb.tick, release: 0.6, res: 0.85, amp: 0.7
+          sleep 0.5
+        end
+        
+        use_synth :chipbass
+        play :g2, cutoff: 78, release: 2, amp: 0.65
+        sleep 1
+      end
+      
+      in_thread do
+        with_fx :reverb, room: 0.25, mix: 0.25 do
+          4.times do
+            sample :bd_haus, amp: 0.8
+            sample :hat_psych, amp: 0.45
+            sleep 0.25
+            sample :hat_psych, amp: 0.4
+            sample :elec_tick, amp: 0.35
+            sleep 0.25
+            sample :elec_snare, amp: 0.7
+            sample :hat_psych, amp: 0.45
+            sample :drum_cymbal_soft, amp: 0.4 if spread(3, 8).tick
+            sleep 0.25
+            sample :hat_psych, amp: 0.4
+            sleep 0.25
+          end
+        end
+      end
+      
+      sleep 16
+    end
+    
+    # Final transition drone - closing atmosphere
+    use_synth :prophet
+    play :c3, cutoff: 100, release: 12, amp: 0.7
+    sample :drum_cymbal_soft, amp: 0.65, rate: 0.85
+    sleep 6
+    
+  end
+end

--- a/docs/sonic-pi/20260430-084458/Electronic Classical Fusion.rb
+++ b/docs/sonic-pi/20260430-084458/Electronic Classical Fusion.rb
@@ -1,0 +1,317 @@
+use_debug false
+use_bpm 120
+
+# Electronic Classical Fusion
+# Style: Electronic Classical Fusion
+# Mood: Dramatic
+
+with_fx :level, amp: 1.2 do
+  with_fx :compressor, threshold: 0.4, clamp_time: 0.01, relax_time: 0.1, slope_above: 0.5 do
+    
+    # Section 1: Dramatic opening in Am — atmospheric with piano, fm, organ pads, minimal percussion
+    2.times do
+      # Long drone sustains underneath
+      use_synth :fm
+      play :a2, release: 16, divisor: 0.5, depth: 8, cutoff: 85, amp: 0.5
+      
+      # Bass foundation
+      use_synth :bass_foundation
+      play :a1, cutoff: 70, release: 8, amp: 0.6
+      sleep 4
+      
+      # Harmony pad
+      in_thread do
+        with_fx :reverb, room: 0.3, mix: 0.35 do
+          use_synth :organ_tonewheel
+          play_chord chord(:a3, :minor7), cutoff: 95, release: 16, amp: 0.5
+          
+          use_synth :prophet
+          8.times do |i|
+            play_chord chord(:a3, :minor), cutoff: (line 85, 105, steps: 8).look, release: 2, amp: 0.4
+            sleep 2
+          end
+        end
+      end
+      
+      # Melody with piano
+      in_thread do
+        with_fx :lpf, cutoff: 100, mix: 0.8 do
+          with_fx :reverb, room: 0.25, mix: 0.3 do
+            use_synth :piano
+            notes = (ring :a4, :c5, :e5, :a5, :e5, :c5, :a4, :gs4)
+            16.times do |i|
+              play notes.tick, release: 0.2, cutoff: (line 90, 120, steps: 16).look, amp: 0.9
+              sleep 0.25
+            end
+          end
+        end
+      end
+      
+      # Walking bass pattern
+      in_thread do
+        sleep 4
+        use_synth :tb303
+        bass_line = (ring :a1, :c2, :e2, :a2, :e2, :c2, :a1, :gs1)
+        8.times do
+          play bass_line.tick, cutoff: 75, release: 0.4, amp: 0.55, res: 0.8
+          sleep 0.5
+        end
+      end
+      
+      # Sparse ceremonial percussion
+      in_thread do
+        # First measure
+        sample :bd_haus, amp: 0.55, cutoff: 90
+        sample :elec_bell, amp: 0.25, rate: 0.8
+        sleep 1
+        sample :hat_psych, amp: 0.2
+        sleep 0.5
+        sample :hat_psych, amp: 0.15
+        sleep 0.5
+        
+        # Second measure
+        sample :bd_haus, amp: 0.5, cutoff: 90
+        sleep 0.5
+        sample :hat_psych, amp: 0.2
+        sleep 0.5
+        sample :elec_snare, amp: 0.4
+        sample :hat_psych, amp: 0.25
+        sleep 0.5
+        sample :hat_psych, amp: 0.15
+        sleep 0.5
+        
+        # Third measure
+        sample :bd_haus, amp: 0.55, cutoff: 90
+        sample :hat_psych, amp: 0.2
+        sleep 0.5
+        sample :hat_psych, amp: 0.15
+        sleep 0.5
+        sample :hat_psych, amp: 0.2
+        sleep 0.5
+        sample :hat_psych, amp: 0.15
+        sleep 0.5
+        
+        # Fourth measure
+        sample :bd_haus, amp: 0.5, cutoff: 90
+        sleep 0.5
+        sample :hat_psych, amp: 0.2
+        sleep 0.5
+        sample :elec_snare, amp: 0.5
+        sample :elec_bell, amp: 0.3, rate: 1.2
+        sleep 0.5
+        sample :hat_psych, amp: 0.15
+        sleep 0.5
+      end
+      
+      sleep 16
+    end
+    
+    # Transition drone — bridges to Section 2 with no silence
+    use_synth :prophet
+    play :a2, cutoff: 90, release: 8, amp: 0.6
+    sample :drum_cymbal_soft, amp: 0.3, rate: 0.9
+    sleep 4
+    
+    # Section 2: Building intensity in Am with saw synth, walking bass, active percussion
+    2.times do
+      # Drone sustains underneath melodic action
+      use_synth :fm
+      play :a2, release: 12, divisor: 0.3, depth: 12, cutoff: 80, amp: 0.4
+      
+      # Sub-bass pedal tone
+      use_synth :subpulse
+      play :a1, cutoff: 60, release: 12, amp: 0.6
+      
+      # Harmony with supersaw
+      in_thread do
+        with_fx :lpf, cutoff: 100, mix: 0.8 do
+          use_synth :supersaw
+          chords_prog = (knit chord(:a3, :minor7), 2, chord(:f3, :major7), 1, chord(:g3, :major), 1)
+          4.times do
+            play_chord chords_prog.tick, cutoff: rrand(90, 110), release: 4, amp: 0.4
+            sleep 4
+          end
+        end
+      end
+      
+      # Melody with saw synth
+      in_thread do
+        use_synth :saw
+        melody = (knit :a3, 2, :c4, 2, :e4, 3, :a4, 1, :e4, 2, :c4, 2, :a3, 2, :gs3, 2)
+        16.times do |i|
+          play melody.tick, release: 0.15, cutoff: rrand(95, 115), amp: 0.95
+          sleep 0.25
+        end
+      end
+      
+      # Walking bass line
+      in_thread do
+        with_fx :lpf, cutoff: 85, mix: 0.8 do
+          use_synth :tb303
+          walking_bass = (knit :a1, 2, :c2, 2, :e2, 2, :a2, 1, :e2, 1, :c2, 2, :a1, 2, :gs1, 2)
+          16.times do
+            play walking_bass.tick, cutoff: rrand(70, 85), release: 0.3, amp: 0.5, res: 0.85
+            sleep 0.25
+          end
+        end
+      end
+      
+      # Crisp electronic percussion
+      in_thread do
+        with_fx :hpf, cutoff: 100, mix: 0.8 do
+          8.times do
+            # Beat 1
+            sample :bd_haus, amp: 0.6, cutoff: 95
+            sample :hat_psych, amp: 0.25
+            sleep 0.25
+            sample :hat_psych, amp: 0.15
+            sleep 0.25
+            
+            # Beat 2
+            sample :elec_snare, amp: 0.5
+            sample :hat_psych, amp: 0.25
+            sleep 0.25
+            sample :hat_psych, amp: 0.15
+            sleep 0.25
+          end
+        end
+      end
+      
+      sleep 16
+    end
+    
+    # Transition drone — bridges to key change with overlap
+    use_synth :prophet
+    play :c3, cutoff: 95, release: 10, amp: 0.65
+    sample :drum_roll, amp: 0.4, rate: 1.2
+    sample :drum_cymbal_soft, amp: 0.35, rate: 1.0
+    sleep 4
+    
+    # Section 3: Key change to C major — triumphant climax with fm, pluck, full percussion
+    3.times do
+      # Long sustaining drone creates atmosphere
+      use_synth :fm
+      play :c3, release: 14, divisor: 0.2, depth: 15, cutoff: 75, amp: 0.45
+      
+      # Deep sustained C root bass
+      use_synth :subpulse
+      play :c2, cutoff: 65, release: 14, amp: 0.6
+      
+      # Harmony with organ and prophet
+      in_thread do
+        with_fx :reverb, room: 0.4, mix: 0.3 do
+          use_synth :organ_tonewheel
+          play_chord chord(:c3, :major7), cutoff: 90, release: 14, amp: 0.55
+          
+          use_synth :prophet
+          progression = (ring chord(:c4, :major7), chord(:a3, :minor7), chord(:f3, :major7), chord(:g3, :major))
+          8.times do |i|
+            play_chord progression.tick, cutoff: (line 95, 115, steps: 8).look, release: 2, amp: 0.45
+            sleep 2
+          end
+        end
+      end
+      
+      # Melody with pluck
+      in_thread do
+        with_fx :echo, phase: 0.375, decay: 1.5, mix: 0.25 do
+          use_synth :pluck
+          climax_notes = (ring :c5, :e5, :g5, :c6, :g5, :e5, :g5, :e5)
+          8.times do
+            play climax_notes.tick, release: 0.3, cutoff: (line 100, 130, steps: 8).look, amp: 1.0
+            sleep 0.5
+          end
+        end
+      end
+      
+      # Classical walking bass
+      in_thread do
+        use_synth :bass_foundation
+        climax_bass = (ring :c2, :e2, :g2, :c3, :g2, :e2, :c2, :g1)
+        8.times do
+          play climax_bass.tick, cutoff: (line 70, 85, steps: 8).look, release: 0.5, amp: 0.6
+          sleep 0.5
+        end
+      end
+      
+      # Full orchestral-electronic percussion
+      in_thread do
+        4.times do
+          sample :bd_haus, amp: 0.7, cutoff: 100
+          sample :hat_psych, amp: 0.3
+          sample :elec_bell, amp: 0.35, rate: 1.5
+          sleep 0.5
+          
+          sample :elec_snare, amp: 0.6
+          sample :hat_psych, amp: 0.3
+          sleep 0.5
+        end
+      end
+      
+      sleep 8
+      
+      # Second phrase with saw
+      in_thread do
+        use_synth :saw
+        phrase2 = (knit :e4, 2, :g4, 2, :c5, 2, :e5, 2)
+        8.times do
+          play phrase2.tick, release: 0.2, cutoff: rrand(90, 110), amp: 0.9
+          sleep 0.5
+        end
+      end
+      
+      # Second phrase bass
+      in_thread do
+        use_synth :tb303
+        phrase2_bass = (knit :c2, 4, :g1, 2, :c2, 2)
+        8.times do
+          play phrase2_bass.tick, cutoff: 80, release: 0.4, amp: 0.55, res: 0.8
+          sleep 0.5
+        end
+      end
+      
+      # Second phrase percussion
+      in_thread do
+        2.times do
+          sample :bd_haus, amp: 0.65, cutoff: 100
+          sample :hat_psych, amp: 0.35
+          sleep 0.25
+          sample :hat_psych, amp: 0.25
+          sleep 0.25
+          
+          sample :elec_snare, amp: 0.65
+          sample :hat_psych, amp: 0.35
+          sleep 0.25
+          sample :hat_psych, amp: 0.25
+          sleep 0.25
+        end
+        
+        sample :bd_haus, amp: 0.65, cutoff: 100
+        sample :drum_cymbal_soft, amp: 0.4, rate: 1.1
+        sleep 0.5
+        
+        sample :elec_snare, amp: 0.7
+        sample :hat_psych, amp: 0.3
+        sleep 0.5
+      end
+      
+      sleep 8
+    end
+    
+    # Final resolving drone — sustains into silence
+    use_synth :prophet
+    play :c3, cutoff: 85, release: 12, amp: 0.7
+    use_synth :supersaw
+    play_chord chord(:c3, :major7), cutoff: 85, release: 12, amp: 0.6
+    use_synth :sine
+    play :c2, cutoff: 80, release: 12, amp: 0.5
+    use_synth :bass_foundation
+    play :c2, cutoff: 70, release: 12, amp: 0.6
+    sample :bd_haus, amp: 0.5, cutoff: 85
+    sample :elec_bell, amp: 0.35, rate: 0.7
+    sleep 2
+    sample :drum_cymbal_soft, amp: 0.3, rate: 0.85
+    sleep 6
+    
+  end
+end

--- a/src/main/java/com/embabel/demo/model/sonicpi/MatchingExamples.java
+++ b/src/main/java/com/embabel/demo/model/sonicpi/MatchingExamples.java
@@ -1,0 +1,12 @@
+package com.embabel.demo.model.sonicpi;
+
+import jakarta.annotation.Nonnull;
+import java.util.List;
+
+/**
+ * Structured response from the LLM example-selection prompt. Wrapping the list in a record
+ * forces the framework's structured-output mode to return a JSON object matching this schema,
+ * which prevents the LLM from wrapping the list in prose like "I have selected: [...]".
+ */
+public record MatchingExamples(@Nonnull List<String> matchingPaths) {
+}

--- a/src/main/java/com/embabel/demo/prompt/persona/SonicPiExamplesContributor.java
+++ b/src/main/java/com/embabel/demo/prompt/persona/SonicPiExamplesContributor.java
@@ -2,6 +2,7 @@ package com.embabel.demo.prompt.persona;
 
 import com.embabel.agent.api.common.Ai;
 import com.embabel.common.ai.prompt.PromptContributor;
+import com.embabel.demo.model.sonicpi.MatchingExamples;
 import com.embabel.demo.model.sonicpi.SonicPiExampleStoreEntry;
 import com.embabel.demo.model.sonicpi.SonicPiMetadata;
 import com.embabel.demo.service.SonicPiExampleIndexer;
@@ -38,14 +39,6 @@ public class SonicPiExamplesContributor implements PromptContributor {
         this.indexer = indexer;
         this.properties = properties;
         this.ai = ai;
-    }
-
-    /**
-     * Structured response from the LLM example-selection prompt. Wrapping the list in a record
-     * forces the framework's structured-output mode to return a JSON object matching this schema,
-     * which prevents the LLM from wrapping the list in prose like "I have selected: [...]".
-     */
-    public record MatchingExamples(@Nonnull List<String> matchingPaths) {
     }
 
     /**

--- a/src/main/java/com/embabel/demo/prompt/persona/SonicPiExamplesContributor.java
+++ b/src/main/java/com/embabel/demo/prompt/persona/SonicPiExamplesContributor.java
@@ -5,13 +5,9 @@ import com.embabel.common.ai.prompt.PromptContributor;
 import com.embabel.demo.model.sonicpi.SonicPiExampleStoreEntry;
 import com.embabel.demo.model.sonicpi.SonicPiMetadata;
 import com.embabel.demo.service.SonicPiExampleIndexer;
-import com.fasterxml.jackson.core.type.TypeReference;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import jakarta.annotation.Nonnull;
-import java.io.IOException;
 import java.util.List;
 import java.util.Map;
-import java.util.stream.Collectors;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Component;
@@ -33,7 +29,6 @@ public class SonicPiExamplesContributor implements PromptContributor {
     private final SonicPiExampleIndexer indexer;
     private final SonicPiExamplesProperties properties;
     private final Ai ai;
-    private final ObjectMapper objectMapper;
 
     public SonicPiExamplesContributor(@Nonnull SonicPiExampleStore store,
                                      @Nonnull SonicPiExampleIndexer indexer,
@@ -43,7 +38,14 @@ public class SonicPiExamplesContributor implements PromptContributor {
         this.indexer = indexer;
         this.properties = properties;
         this.ai = ai;
-        this.objectMapper = new ObjectMapper();
+    }
+
+    /**
+     * Structured response from the LLM example-selection prompt. Wrapping the list in a record
+     * forces the framework's structured-output mode to return a JSON object matching this schema,
+     * which prevents the LLM from wrapping the list in prose like "I have selected: [...]".
+     */
+    public record MatchingExamples(@Nonnull List<String> matchingPaths) {
     }
 
     /**
@@ -89,11 +91,11 @@ public class SonicPiExamplesContributor implements PromptContributor {
 
     private @Nonnull List<String> selectMatchingExamples(
             @Nonnull SonicPiMetadata targetMetadata,
-            @Nonnull List<SonicPiExampleStoreEntry> candidates) throws IOException {
+            @Nonnull List<SonicPiExampleStoreEntry> candidates) {
 
-        String response = ai.withDefaultLlm()
+        MatchingExamples selection = ai.withDefaultLlm()
                 .withTemplate("sonicpi/select-matching-examples.jinja")
-                .createObject(String.class, Map.of(
+                .createObject(MatchingExamples.class, Map.of(
                         "targetStyle", targetMetadata.style(),
                         "targetMood", targetMetadata.mood(),
                         "targetTempoBpm", String.valueOf(targetMetadata.tempoBpm()),
@@ -104,8 +106,7 @@ public class SonicPiExamplesContributor implements PromptContributor {
                         "examples", candidates,
                         "maxExamples", String.valueOf(properties.maxExamples())));
 
-        return objectMapper.readValue(response, new TypeReference<>() {
-        });
+        return selection.matchingPaths() == null ? List.of() : selection.matchingPaths();
     }
 
     private @Nonnull String formatExamples(@Nonnull List<SonicPiExampleStoreEntry> entries) {

--- a/src/main/java/com/embabel/demo/prompt/persona/SonicPiExamplesContributor.java
+++ b/src/main/java/com/embabel/demo/prompt/persona/SonicPiExamplesContributor.java
@@ -93,6 +93,16 @@ public class SonicPiExamplesContributor implements PromptContributor {
             @Nonnull SonicPiMetadata targetMetadata,
             @Nonnull List<SonicPiExampleStoreEntry> candidates) {
 
+        List<Map<String, Object>> candidatePayload = candidates.stream()
+                .map(entry -> Map.<String, Object>of(
+                        "relativePath", entry.relativePath(),
+                        "style", entry.sonicPiMetadata().style(),
+                        "mood", entry.sonicPiMetadata().mood(),
+                        "tempoBpm", entry.sonicPiMetadata().tempoBpm(),
+                        "key", entry.sonicPiMetadata().key(),
+                        "melodyInstruments", String.join(", ", entry.sonicPiMetadata().melodyInstruments())))
+                .toList();
+
         MatchingExamples selection = ai.withDefaultLlm()
                 .withTemplate("sonicpi/select-matching-examples.jinja")
                 .createObject(MatchingExamples.class, Map.of(
@@ -103,7 +113,7 @@ public class SonicPiExamplesContributor implements PromptContributor {
                         "targetMelodyInstruments", String.join(", ", targetMetadata.melodyInstruments()),
                         "targetHarmonyInstruments", String.join(", ", targetMetadata.harmonyInstruments()),
                         "targetPercussionSamples", String.join(", ", targetMetadata.percussionSamples()),
-                        "examples", candidates,
+                        "examples", candidatePayload,
                         "maxExamples", String.valueOf(properties.maxExamples())));
 
         return selection.matchingPaths() == null ? List.of() : selection.matchingPaths();

--- a/src/main/resources/prompts/sonicpi/select-matching-examples.jinja
+++ b/src/main/resources/prompts/sonicpi/select-matching-examples.jinja
@@ -32,7 +32,9 @@ Select the examples that LOOSELY match the target song. Consider:
 
 Be generous with matching — include examples that could provide useful inspiration even if they don't match every criterion. Select up to {{ maxExamples }} examples.
 
-Return ONLY a JSON array of the matching relative paths, e.g.:
-["sonic-pi-app/magician/acid.rb", "user-songs/sonic-pi-demo/Examples/Crazy Beat.rb"]
+Respond with a JSON object containing a single field `matchingPaths` whose value is the array of selected relative paths. Do not include any prose, commentary, or explanation — only the JSON object.
 
-If no examples match at all, return all available paths (up to {{ maxExamples }}).
+Example response:
+{"matchingPaths": ["sonic-pi-app/magician/acid.rb", "user-songs/sonic-pi-demo/Examples/Crazy Beat.rb"]}
+
+If no examples match at all, return all available paths (up to {{ maxExamples }}) inside `matchingPaths`.

--- a/src/main/resources/prompts/sonicpi/select-matching-examples.jinja
+++ b/src/main/resources/prompts/sonicpi/select-matching-examples.jinja
@@ -15,11 +15,11 @@ Here are the available example songs with their metadata:
 <examples>
 {% for example in examples %}
 - Path: {{ example.relativePath }}
-  Style: {{ example.sonicPiMetadata.style }}
-  Mood: {{ example.sonicPiMetadata.mood }}
-  Tempo: {{ example.sonicPiMetadata.tempoBpm }} BPM
-  Key: {{ example.sonicPiMetadata.key }}
-  Melody instruments: {{ example.sonicPiMetadata.melodyInstruments }}
+  Style: {{ example.style }}
+  Mood: {{ example.mood }}
+  Tempo: {{ example.tempoBpm }} BPM
+  Key: {{ example.key }}
+  Melody instruments: {{ example.melodyInstruments }}
 {% endfor %}
 </examples>
 


### PR DESCRIPTION
## Summary

Two related fixes to LLM-based example selection in `SonicPiExamplesContributor`. The second was hidden by the first — once the parse failure stopped, the contributor returned 0 matches on every call.

### 1. JSON parse failure on prose-wrapped responses

`selectMatchingExamples` was asking the LLM for a raw JSON array via `createObject(String.class, ...)` and parsing the response with Jackson. When the LLM wrapped the array in prose (e.g. `"I have selected: [...]"`), `ObjectMapper` rejected the leading `'I'` token and the contributor fell back to all allowed examples.

**Fix:** typed structured output via a `MatchingExamples(List<String> matchingPaths)` record returned by `createObject(MatchingExamples.class, ...)`. Updated `select-matching-examples.jinja` to describe the new JSON object shape and forbid commentary. Dropped the manual `ObjectMapper`.

### 2. Empty candidate list rendered to LLM (Jinjava + Java records)

After fix 1 the parse error was gone, but every call returned `LLM selected 0 matching examples out of 43 allowed` — and the logs showed hundreds of:
```
WARN  c.e.c.t.t.JinjavaTemplateRenderer - Cannot resolve property 'relativePath' in 'SonicPiExampleStoreEntry[...]'
WARN  c.e.c.t.t.JinjavaTemplateRenderer - Cannot resolve property 'sonicPiMetadata' in 'SonicPiExampleStoreEntry[...]'
```

Jinjava resolves properties via Java bean conventions (`getRelativePath()`), but Java records expose accessors named after the field (`relativePath()`). Passing a `List<SonicPiExampleStoreEntry>` into the template made every `{{ example.relativePath }}` render empty, so the LLM saw 43 blank bullet points and correctly returned `[]`.

**Fix:** convert candidates to `List<Map<String, Object>>` with flat keys before passing to `createObject`, and update the Jinja template to read `example.style` / `example.mood` / etc. directly.

## Test plan

- [ ] Run the SonicPi E2E controller against a real LLM and confirm `LLM selected N matching examples out of M allowed` shows N > 0 for non-trivial cases.
- [ ] Verify no `Cannot resolve property` warnings appear in the logs.
- [ ] Verify no `JsonParseException` from `selectMatchingExamples`.
- [ ] Confirm the fallback path still works when the LLM call genuinely fails (warning logged, agent still produces output).

🤖 Generated with [Claude Code](https://claude.com/claude-code)