### PR TITLE
Tighten Sonic Pi example selection: stricter match, max 3

### DIFF
--- a/src/main/java/com/embabel/demo/prompt/persona/SonicPiExamplesContributor.java
+++ b/src/main/java/com/embabel/demo/prompt/persona/SonicPiExamplesContributor.java
@@ -68,7 +68,22 @@ public class SonicPiExamplesContributor implements PromptContributor {
                     .filter(entry -> matchingPaths.contains(entry.relativePath()))
                     .toList();
 
-            LOG.info("LLM selected {} matching examples out of {} allowed", matched.size(), allowed.size());
+            if (matched.isEmpty()) {
+                LOG.info(
+                        "LLM found no matching examples out of {} allowed. To improve future generations, add examples with: style='{}', mood='{}', tempo~{} BPM, key='{}', melody instruments=[{}], harmony instruments=[{}], percussion samples=[{}]",
+                        allowed.size(),
+                        targetMetadata.style(),
+                        targetMetadata.mood(),
+                        targetMetadata.tempoBpm(),
+                        targetMetadata.key(),
+                        String.join(", ", targetMetadata.melodyInstruments()),
+                        String.join(", ", targetMetadata.harmonyInstruments()),
+                        String.join(", ", targetMetadata.percussionSamples()));
+            } else {
+                List<String> matchedPaths = matched.stream().map(SonicPiExampleStoreEntry::relativePath).toList();
+                LOG.info("LLM selected {} matching examples out of {} allowed: {}",
+                        matched.size(), allowed.size(), matchedPaths);
+            }
             return formatExamples(matched);
         } catch (Exception e) {
             LOG.warn("LLM example selection failed — falling back to all allowed examples", e);

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -37,7 +37,7 @@ spring:
 sonic-pi:
   examples:
     store-directory: sonic-pi-examples
-    max-examples: 20
+    max-examples: 3
 
   instructions: |
     You are an expert Sonic Pi programmer, familiar with music theory and composition.

--- a/src/main/resources/prompts/sonicpi/add-bass.jinja
+++ b/src/main/resources/prompts/sonicpi/add-bass.jinja
@@ -13,6 +13,8 @@ Use the following instruments:
 {{ bassInstruments }}
 </bassInstruments>
 
+Every name in <bassInstruments> is a SYNTH. Always invoke them with `use_synth :name` — NEVER with `sample :name`. Do not invent or reach for sample names (e.g. `bass_voxy_c`, `bass_dnb_f`) — those are samples, not synths, and Sonic Pi will fail if they appear after `use_synth`. The bass track must be entirely synth-driven; percussion is handled by a separate track.
+
 The bass provides the LOW-REGISTER FOUNDATION — root notes and fifths that anchor the harmony.
 Use LOW OCTAVES (`:c2`, `:e2`, `:g2` range — octave 1-3) to sit well below the melody and harmony.
 Think BASS GUITAR or ELECTRONIC SUB BASS — not kick drums, not chords, not pads.

--- a/src/main/resources/prompts/sonicpi/select-matching-examples.jinja
+++ b/src/main/resources/prompts/sonicpi/select-matching-examples.jinja
@@ -23,18 +23,22 @@ Here are the available example songs with their metadata:
 {% endfor %}
 </examples>
 
-Select the examples that LOOSELY match the target song. Consider:
-- Similar style or genre family (e.g. "techno" matches "electronic", "blues" matches "jazz")
-- Compatible mood (e.g. "energetic" matches "vibrant", "calm" matches "serene")
-- Roughly similar tempo range (within +/- 40 BPM)
-- Overlapping instruments or instrument families
-- Compatible key or mode (e.g. minor keys match other minor keys)
+Select ONLY examples that are a STRONG match for the target. Be strict and selective — irrelevant examples mislead the LLM more than they help. An example qualifies only if it satisfies ALL of the following:
 
-Be generous with matching — include examples that could provide useful inspiration even if they don't match every criterion. Select up to {{ maxExamples }} examples.
+1. Same or directly adjacent style/genre. "Techno" matches "house" or "electronic"; it does NOT match "classical", "blues", or "ambient". If unsure, reject.
+2. Compatible mood. "Energetic" matches "vibrant" or "driving"; it does NOT match "calm" or "melancholic".
+3. Tempo within ±15 BPM of the target.
+4. Same mode (major matches major, minor matches minor). Different modes are a reject.
+5. At least one shared melody instrument or instrument family.
+
+Rank the qualifying examples by how closely they match and return at most {{ maxExamples }}. Prefer fewer strong matches over padding the list with weaker ones.
+
+If NO examples qualify under these rules, return an empty array. Do NOT fall back to returning unrelated examples.
 
 Respond with a JSON object containing a single field `matchingPaths` whose value is the array of selected relative paths. Do not include any prose, commentary, or explanation — only the JSON object.
 
 Example response:
 {"matchingPaths": ["sonic-pi-app/magician/acid.rb", "user-songs/sonic-pi-demo/Examples/Crazy Beat.rb"]}
 
-If no examples match at all, return all available paths (up to {{ maxExamples }}) inside `matchingPaths`.
+Empty response when nothing qualifies:
+{"matchingPaths": []}

--- a/src/main/resources/prompts/sonicpi/to-meta-data.jinja
+++ b/src/main/resources/prompts/sonicpi/to-meta-data.jinja
@@ -41,3 +41,9 @@ classical, jazz, rock, pop, hip-hop, electronic, folk, blues, reggae, country, m
 grunge, ambient, techno, house, trance, dubstep, drum and bass, swing, bossa nova, salsa, tango, bluegrass, Celtic
 flamenco, calypso, zydeco, surf, psychedelic, experimental
 </styles>
+
+Instrument and sample selection — MUST follow these rules:
+- `melodyInstruments`, `harmonyInstruments`, and `bassInstruments` MUST be SYNTH names chosen from the available `instruments` list provided above. These will be played with `use_synth :name`.
+- `percussionSamples` MUST be SAMPLE names chosen from the available `samples` list provided above. These will be played with `sample :name`.
+- A name appearing in the `samples` list is a SAMPLE, even if it has "bass" in its name (e.g. `bass_voxy_c`, `bass_dnb_f`, `bass_drop_c`). Never place a sample name in `bassInstruments` — it will fail because samples cannot be invoked as synths.
+- For bass synths, prefer names like `bass_foundation`, `bass_highend`, `chipbass`, `subpulse`, `tb303`, `fm`, `saw`, `dsaw`, or `tri` from the `instruments` list.


### PR DESCRIPTION
## Summary

- Lower `sonic-pi.examples.max-examples` from `20` to `3` so few-shot prompts stay focused.
- Rewrite `prompts/sonicpi/select-matching-examples.jinja` with a strict matching rubric (style adjacency, mood compatibility, tempo within ±15 BPM, matching mode, shared instruments) and require ALL criteria. Returns `[]` instead of falling back to all examples when nothing qualifies.
- Log the relative paths of matched examples; when no example qualifies, log the target metadata so we know what kind of example song would need to be added to the store.
- Stop the bass action treating sample names as synths. Both `to-meta-data.jinja` and `add-bass.jinja` now make explicit that `bassInstruments` are SYNTHS only — sample names like `bass_voxy_c` (which belong to the samples list and must be played with `sample :name`) must never leak into the bass synth list.

## Why

`SonicPiExamplesContributor` was picking up to 20 examples and the prompt encouraged "generous" matching with a ±40 BPM window plus an explicit fallback to "return all available paths" when nothing matched. That diluted the signal and pulled irrelevant styles into the LLM's few-shot context. The new logging lets us see selection quality at a glance and surfaces gaps in the example library.

Separately, the bass action was emitting `use_synth :bass_voxy_c` which is a runtime error — `bass_voxy_c` is a sample, not a synth. The metadata extraction prompt did not constrain `*Instruments` fields to the synth list, and the bass prompt did not warn the LLM not to call sample names as synths.

## Test plan

- [ ] Run `mvn spring-boot:run` and POST a Sonic Pi request — confirm logs show `LLM selected N matching examples ... [paths]` with N ≤ 3.
- [ ] Send a deliberately unusual style/mood pairing — confirm the log says `no matching examples` and lists the target metadata.
- [ ] Inspect the generated bass section — confirm `use_synth` is only called with synth names (no `bass_voxy_c` / `bass_dnb_f` etc.).
- [ ] Spot-check generated `.rb` output to confirm it still references idiomatic Sonic Pi patterns.

🤖 Generated with [Claude Code](https://claude.com/claude-code)