### PR TITLE
Forbid invented sample names in Sonic Pi prompts

### DIFF
--- a/src/main/java/com/embabel/demo/prompt/persona/SonicPiPromptContributor.java
+++ b/src/main/java/com/embabel/demo/prompt/persona/SonicPiPromptContributor.java
@@ -23,10 +23,10 @@ public record SonicPiPromptContributor(
         return """
                 %s
                 
-                Only these instruments are available in Sonic Pi:
+                Only these instruments are available in Sonic Pi. Do NOT use any instrument name not in this list:
                 {"instruments":[%s]}
-                
-                Only these samples are available in Sonic Pi:
+
+                Only these samples are available in Sonic Pi. Do NOT use any sample name not in this list — inventing a sample name (e.g. `:elec_snap`) will cause the script to fail at runtime:
                 {"samples":[%s]}
                 """.formatted(
                 instructions,

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -137,6 +137,8 @@ sonic-pi:
     Use ':maj9' for major 9th, ':maj11' for major 11th. There is no major 13th chord — use '13' instead.
     For minor variants use ':m9', ':m11', ':m13'.
 
+    IMPORTANT: NEVER invent sample names. Every `sample :name` call MUST use a name that appears verbatim in the allowed samples list above. Do NOT guess, abbreviate, or extrapolate plausible-sounding names from the patterns you see (e.g. because `:elec_snare` exists, do not assume `:elec_snap` exists — it does NOT). If the exact sample you want is not in the list, choose the closest one that IS in the list. Common hallucinations to avoid: `:elec_snap`, `:elec_kick`, `:drum_kick`, `:hat_closed`, `:hat_open` — none of these exist.
+
     Full range of C chords:
     <cChords>
       chord(:C, '1')


### PR DESCRIPTION
## Summary
- The LLM hallucinated `sample :elec_snap` (not a real Sonic Pi sample), likely extrapolating from `:elec_snare`/`:elec_lo_snare` in the allow-list.
- Strengthen the wording the `SonicPiPromptContributor` wraps around the samples list so the allow-list is unmissable, and warn that inventing names will fail at runtime.
- Add an `IMPORTANT` rule to `sonic-pi.instructions` (matching the existing `:maj7` / `:major9` style) calling out `:elec_snap` and other common hallucinations by name.

No `.rb` files under `docs/sonic-pi/*` were edited — fix is in the prompt only.

## Test plan
- [ ] `mvn compile` — passes
- [ ] `mvn test` — no new failures (pre-existing `StoryAgentIntegrationTest` failure also occurs on `main`)
- [ ] Re-run a Sonic Pi generation and confirm `:elec_snap` no longer appears in output

🤖 Generated with [Claude Code](https://claude.com/claude-code)