### PR TITLE
Lower Sonic Pi master :level amp from 1.2 to 0.5 to stop static

### DIFF
--- a/src/main/resources/prompts/sonicpi/combine-all-parts.jinja
+++ b/src/main/resources/prompts/sonicpi/combine-all-parts.jinja
@@ -45,7 +45,7 @@ If any FX is missing `mix:`, add it: `mix: 0.2-0.35` for reverb, `mix: 0.15-0.3`
 Remove any `:distortion` FX — it causes crackling.
 Ensure all `with_fx` blocks are INSIDE `N.times do` blocks, not wrapping them from outside.
 Add `use_debug false` as the very first line of the script.
-Wrap ALL sections inside `with_fx :level, amp: 1.2 do` and `with_fx :compressor, threshold: 0.4, clamp_time: 0.01, relax_time: 0.1, slope_above: 0.5 do` as a master limiter and compressor to prevent clipping.
+Wrap ALL sections inside `with_fx :level, amp: 0.5 do` and `with_fx :compressor, threshold: 0.4, clamp_time: 0.01, relax_time: 0.1, slope_above: 0.5 do` as a master limiter and compressor to prevent clipping. Never raise the master `amp:` above 0.5 — this is the most common cause of static and crackling.
 Ensure every synth `play` call has a `cutoff:` parameter (80-120 range) and a `release:` parameter. This is critical for clean audio.
 Any loop-based samples must use `beat_stretch:` to align with the BPM.
 Use `.times do` loops for repeating patterns — do not write out every bar individually. Keep the script concise.


### PR DESCRIPTION
## Summary
- The combine prompt (`combine-all-parts.jinja`) was instructing `with_fx :level, amp: 1.2` while the audio-quality rules in `application.yml` specified `amp: 0.5`. The combine step won, so every recent generation ran the master bus 20% over unity.
- With melody amps at 0.95, drum samples at 0.85+, bass at 0.72, and harmony all summing inside each `N.times` block, the signal regularly exceeded 1.0 before the master `:level` boost — producing audible static and crackling.
- Aligned the combine prompt to `amp: 0.5` and added an explicit "never raise above 0.5" rule so future edits don't drift back up.

## Test plan
- [ ] Regenerate a Sonic Pi script via `/sonic-pi` and confirm the output starts with `with_fx :level, amp: 0.5 do`
- [ ] Play the generated script in Sonic Pi and confirm the static/crackling is gone
- [ ] Spot-check 2-3 different styles (EDM, classical, ambient) to ensure the lower master amp is still audibly loud enough

🤖 Generated with [Claude Code](https://claude.com/claude-code)