### PR TITLE
Drop withTemperature on agent LLM calls

### DIFF
--- a/src/main/java/com/embabel/demo/agent/DadJokeAgent.java
+++ b/src/main/java/com/embabel/demo/agent/DadJokeAgent.java
@@ -36,14 +36,14 @@ public class DadJokeAgent {
     @Action
     public Jokes writeJokes(UserInput userInput, OperationContext context) {
         return context.ai()
-                .withLlm(LlmOptions.withLlmForRole("best").withTemperature(0.8))
+                .withLlm(LlmOptions.withLlmForRole("best"))
                 .createObject("Write %s Dad Jokes based on: %s".formatted(jokeCount, userInput.getContent()), Jokes.class);
     }
 
     @Action
     public JokesAndRatings rateJokes(Jokes jokes, OperationContext context) {
         List<JokeAndRating> list = jokes.jokes().stream().parallel().map(joke -> context.ai()
-                .withLlm(LlmOptions.withLlmForRole("cheapest").withTemperature(0.1))
+                .withLlm(LlmOptions.withLlmForRole("cheapest"))
                 .createObject("On a scale from 1 to %s, rate this joke: %s".formatted(jokeCount, joke), JokeAndRating.class)).toList();
         return new JokesAndRatings(list);
     }

--- a/src/main/java/com/embabel/demo/agent/SonicPiAgent.java
+++ b/src/main/java/com/embabel/demo/agent/SonicPiAgent.java
@@ -58,7 +58,7 @@ public class SonicPiAgent {
     public SonicPiMetadata toSonicPiMetadata(UserInput userInput, OperationContext context) {
         LOG.info("Converting user input to {}", userInput);
         return context.ai()
-                .withLlm(LlmOptions.withAutoLlm().withTemperature(1.0))
+                .withLlm(LlmOptions.withAutoLlm())
                 .withPromptContributor(sonicPiPromptContributor)
                 .withTemplate("sonicpi/to-meta-data.jinja")
                 .createObject(SonicPiMetadata.class, Map.of(
@@ -70,7 +70,7 @@ public class SonicPiAgent {
     public SonicPiScriptWithMelody createMelody(SonicPiMetadata sonicPiMetadata, OperationContext context) {
         LOG.info("Creating melody for {}", sonicPiMetadata);
         return context.ai()
-                .withLlm(LlmOptions.withAutoLlm().withTemperature(1.0))
+                .withLlm(LlmOptions.withAutoLlm())
                 .withPromptContributor(sonicPiPromptContributor)
                 .withPromptContributor(() -> sonicPiExamplesContributor.contributionFor(sonicPiMetadata))
                 .withTemplate("sonicpi/create-melody.jinja")
@@ -92,7 +92,7 @@ public class SonicPiAgent {
             SonicPiScriptWithMelody sonicPiScriptWithMelody, SonicPiMetadata sonicPiMetadata, OperationContext context) {
         LOG.info("Adding harmony track to {}", sonicPiScriptWithMelody);
         return context.ai()
-                .withLlm(LlmOptions.withAutoLlm().withTemperature(1.0))
+                .withLlm(LlmOptions.withAutoLlm())
                 .withPromptContributor(sonicPiPromptContributor)
                 .withPromptContributor(() -> sonicPiExamplesContributor.contributionFor(sonicPiMetadata))
                 .withTemplate("sonicpi/add-harmony.jinja")
@@ -107,7 +107,7 @@ public class SonicPiAgent {
             SonicPiScriptWithMelody sonicPiScriptWithMelody, SonicPiMetadata sonicPiMetadata, OperationContext context) {
         LOG.info("Adding percussion track to {}", sonicPiScriptWithMelody);
         return context.ai()
-                .withLlm(LlmOptions.withAutoLlm().withTemperature(1.0))
+                .withLlm(LlmOptions.withAutoLlm())
                 .withPromptContributor(sonicPiPromptContributor)
                 .withPromptContributor(() -> sonicPiExamplesContributor.contributionFor(sonicPiMetadata))
                 .withTemplate("sonicpi/add-percussion.jinja")
@@ -122,7 +122,7 @@ public class SonicPiAgent {
             SonicPiScriptWithMelody sonicPiScriptWithMelody, SonicPiMetadata sonicPiMetadata, OperationContext context) {
         LOG.info("Adding bass track to {}", sonicPiScriptWithMelody);
         return context.ai()
-                .withLlm(LlmOptions.withAutoLlm().withTemperature(1.0))
+                .withLlm(LlmOptions.withAutoLlm())
                 .withPromptContributor(sonicPiPromptContributor)
                 .withPromptContributor(() -> sonicPiExamplesContributor.contributionFor(sonicPiMetadata))
                 .withTemplate("sonicpi/add-bass.jinja")
@@ -151,7 +151,7 @@ public class SonicPiAgent {
         LOG.info("{}", sonicPiScriptWithBass.scriptContent());
 
         var rawScriptContent = context.ai()
-                .withLlm(LlmOptions.withAutoLlm().withTemperature(1.0).withTimeout(Duration.ofSeconds(120)))
+                .withLlm(LlmOptions.withAutoLlm().withTimeout(Duration.ofSeconds(120)))
                 .withPromptContributor(sonicPiPromptContributor)
                 .withPromptContributor(() -> sonicPiExamplesContributor.contributionFor(sonicPiMetadata))
                 .withTemplate("sonicpi/combine-all-parts.jinja")

--- a/src/main/java/com/embabel/demo/agent/StoryAgent.java
+++ b/src/main/java/com/embabel/demo/agent/StoryAgent.java
@@ -70,7 +70,7 @@ public class StoryAgent {
         List<String> storyTexts = IntStream.range(0, storyCount).parallel().mapToObj(i ->
                 retry("writeStory", () ->
                         context.ai()
-                                .withLlm(LlmOptions.withLlmForRole("best").withTemperature(0.8))
+                                .withLlm(LlmOptions.withLlmForRole("best"))
                                 .withPromptContributor(StoryPersonas.WRITER)
                                 .withTemplate("story/write-story-template.jinja")
                                 .createObject(String.class,
@@ -89,7 +89,7 @@ public class StoryAgent {
         List<ReviewedStory> reviewed = stories.stories().stream().parallel().map(story ->
                 retry("reviewStory", () -> {
                     var review = context.ai()
-                            .withLlm(LlmOptions.withLlmForRole("cheapest").withTemperature(0.1))
+                            .withLlm(LlmOptions.withLlmForRole("cheapest"))
                             .withPromptContributor(StoryPersonas.REVIEWER)
                             .withTemplate("story/review-story-template.jinja")
                             .createObject(StoryReview.class,


### PR DESCRIPTION
## Summary
- Claude Opus 4.7 deprecated the `temperature` parameter and returns HTTP 400 (`temperature is deprecated for this model`) for any agent routed to it. In the default `all` profile, `best: claude-opus-4-7`, so `StoryAgent.writeStories` and `DadJokeAgent.writeJokes` were failing.
- Removed `.withTemperature(...)` from every LLM call in `DadJokeAgent`, `StoryAgent`, and `SonicPiAgent`. The parameter is no longer sent.

## Test plan
- [ ] `mvn test`
- [ ] `mvn spring-boot:run` and exercise `/story`, `/dadJoke`, `/sonic-pi` against the `all` profile (Anthropic via Opus 4.7 + Haiku 4.5 + Sonnet 4.6) — confirm no 400 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)