### PR TITLE
Upgrade Spring Boot, Embabel agent, and Spring Shell versions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3,10 +3,11 @@
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
+    <!-- https://mvnrepository.com/artifact/org.springframework.boot/spring-boot-starter-parent -->
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>3.5.11</version>
+        <version>3.5.16</version>
         <relativePath/> <!-- Lookup parent from repository -->
     </parent>
     <groupId>com.github.stevendoolan</groupId>
@@ -26,10 +27,10 @@
         <spring.boot.mainClass>com.github.stevendoolan.embabeldemo.Application</spring.boot.mainClass>
 
         <!-- https://mvnrepository.com/artifact/com.embabel.agent/embabel-agent-starter -->
-        <embabel-agent.version>0.3.4</embabel-agent.version>
+        <embabel-agent.version>0.5.0</embabel-agent.version>
 
         <!-- https://mvnrepository.com/artifact/org.springframework.shell/spring-shell-standard -->
-        <spring-shell.version>3.4.2</spring-shell.version>
+        <spring-shell.version>3.4.3</spring-shell.version>
     </properties>
 
     <dependencies>


### PR DESCRIPTION
## Summary

- Spring Boot parent: 3.5.11 → 3.5.16
- Embabel agent starter: 0.3.4 → 0.5.0
- Spring Shell: 3.4.2 → 3.4.3

## Test plan

- [x] `mvn test` passes
- [x] App starts with `mvn spring-boot:run -Panthropic`
- [x] MCP tools respond as expected

🤖 Generated with [Claude Code](https://claude.com/claude-code)