### PR TITLE
Testing graceful-shutdown-with-mcp fix in embabel-agent

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -59,7 +59,7 @@ The `sonic-pi-examples/` directory is **gitignored** (copyrighted Sonic Pi sampl
 
 ### Prompt templates
 
-Jinja templates under `src/main/resources/prompts/{sonicpi,story}/` are referenced by `withTemplate("sonicpi/foo.jinja")`. To change agent behaviour, edit prompts and the `sonic-pi.instructions` block in `application.yml` rather than the Java action code.
+Jinja templates under `src/main/resources/prompts/{sonicpi,story}/` are referenced by `rendering("sonicpi/foo.jinja")`. To change agent behaviour, edit prompts and the `sonic-pi.instructions` block in `application.yml` rather than the Java action code.
 
 ## Gotchas
 

--- a/pom.xml
+++ b/pom.xml
@@ -27,7 +27,7 @@
         <spring.boot.mainClass>com.github.stevendoolan.embabeldemo.Application</spring.boot.mainClass>
 
         <!-- https://mvnrepository.com/artifact/com.embabel.agent/embabel-agent-starter -->
-        <embabel-agent.version>0.5.0</embabel-agent.version>
+        <embabel-agent.version>1.0.0-RC1-SNAPSHOT</embabel-agent.version>
 
         <!-- https://mvnrepository.com/artifact/org.springframework.shell/spring-shell-standard -->
         <spring-shell.version>3.4.3</spring-shell.version>

--- a/src/main/java/com/github/stevendoolan/embabeldemo/agent/SonicPiAgent.java
+++ b/src/main/java/com/github/stevendoolan/embabeldemo/agent/SonicPiAgent.java
@@ -60,7 +60,7 @@ public class SonicPiAgent {
         return context.ai()
                 .withLlm(LlmOptions.withAutoLlm())
                 .withPromptContributor(sonicPiPromptContributor)
-                .withTemplate("sonicpi/to-meta-data.jinja")
+                .rendering("sonicpi/to-meta-data.jinja")
                 .createObject(SonicPiMetadata.class, Map.of(
                         "userInput", userInput.getContent()
                 ));
@@ -73,7 +73,7 @@ public class SonicPiAgent {
                 .withLlm(LlmOptions.withAutoLlm())
                 .withPromptContributor(sonicPiPromptContributor)
                 .withPromptContributor(() -> sonicPiExamplesContributor.contributionFor(sonicPiMetadata))
-                .withTemplate("sonicpi/create-melody.jinja")
+                .rendering("sonicpi/create-melody.jinja")
                 .createObject(SonicPiScriptWithMelody.class, Map.of(
                         "style", sonicPiMetadata.style(),
                         "songTitle", sonicPiMetadata.songTitle(),
@@ -95,7 +95,7 @@ public class SonicPiAgent {
                 .withLlm(LlmOptions.withAutoLlm())
                 .withPromptContributor(sonicPiPromptContributor)
                 .withPromptContributor(() -> sonicPiExamplesContributor.contributionFor(sonicPiMetadata))
-                .withTemplate("sonicpi/add-harmony.jinja")
+                .rendering("sonicpi/add-harmony.jinja")
                 .createObject(SonicPiScriptWithHarmony.class, Map.of(
                         "melodyScriptContent", sonicPiScriptWithMelody.scriptContent(),
                         "harmonyDescription", sonicPiMetadata.harmonyDescription(),
@@ -110,7 +110,7 @@ public class SonicPiAgent {
                 .withLlm(LlmOptions.withAutoLlm())
                 .withPromptContributor(sonicPiPromptContributor)
                 .withPromptContributor(() -> sonicPiExamplesContributor.contributionFor(sonicPiMetadata))
-                .withTemplate("sonicpi/add-percussion.jinja")
+                .rendering("sonicpi/add-percussion.jinja")
                 .createObject(SonicPiScriptWithPercussion.class, Map.of(
                         "melodyScriptContent", sonicPiScriptWithMelody.scriptContent(),
                         "percussionDescription", sonicPiMetadata.percussionDescription(),
@@ -125,7 +125,7 @@ public class SonicPiAgent {
                 .withLlm(LlmOptions.withAutoLlm())
                 .withPromptContributor(sonicPiPromptContributor)
                 .withPromptContributor(() -> sonicPiExamplesContributor.contributionFor(sonicPiMetadata))
-                .withTemplate("sonicpi/add-bass.jinja")
+                .rendering("sonicpi/add-bass.jinja")
                 .createObject(SonicPiScriptWithBass.class, Map.of(
                         "melodyScriptContent", sonicPiScriptWithMelody.scriptContent(),
                         "bassDescription", sonicPiMetadata.bassDescription(),
@@ -154,7 +154,7 @@ public class SonicPiAgent {
                 .withLlm(LlmOptions.withAutoLlm().withTimeout(Duration.ofSeconds(120)))
                 .withPromptContributor(sonicPiPromptContributor)
                 .withPromptContributor(() -> sonicPiExamplesContributor.contributionFor(sonicPiMetadata))
-                .withTemplate("sonicpi/combine-all-parts.jinja")
+                .rendering("sonicpi/combine-all-parts.jinja")
                 .createObject(String.class, Map.of(
                         "melodyScriptContent", sonicPiScriptWithMelody.scriptContent(),
                         "harmonyScriptContent", sonicPiScriptWithHarmony.scriptContent(),

--- a/src/main/java/com/github/stevendoolan/embabeldemo/agent/StoryAgent.java
+++ b/src/main/java/com/github/stevendoolan/embabeldemo/agent/StoryAgent.java
@@ -72,7 +72,7 @@ public class StoryAgent {
                         context.ai()
                                 .withLlm(LlmOptions.withLlmForRole("best"))
                                 .withPromptContributor(StoryPersonas.WRITER)
-                                .withTemplate("story/write-story-template.jinja")
+                                .rendering("story/write-story-template.jinja")
                                 .createObject(String.class,
                                         Map.of(
                                                 "storyWordCount", storyWordCount,
@@ -91,7 +91,7 @@ public class StoryAgent {
                     var review = context.ai()
                             .withLlm(LlmOptions.withLlmForRole("cheapest"))
                             .withPromptContributor(StoryPersonas.REVIEWER)
-                            .withTemplate("story/review-story-template.jinja")
+                            .rendering("story/review-story-template.jinja")
                             .createObject(StoryReview.class,
                                     Map.of(
                                             "reviewWordCount", reviewWordCount,

--- a/src/main/java/com/github/stevendoolan/embabeldemo/prompt/persona/SonicPiExamplesContributor.java
+++ b/src/main/java/com/github/stevendoolan/embabeldemo/prompt/persona/SonicPiExamplesContributor.java
@@ -160,7 +160,7 @@ public class SonicPiExamplesContributor implements PromptContributor {
                 .toList();
 
         MatchingExamples selection = ai.withDefaultLlm()
-                .withTemplate("sonicpi/select-matching-examples.jinja")
+                .rendering("sonicpi/select-matching-examples.jinja")
                 .createObject(MatchingExamples.class, Map.of(
                         "targetStyle", targetMetadata.style(),
                         "targetMood", targetMetadata.mood(),

--- a/src/main/java/com/github/stevendoolan/embabeldemo/service/SonicPiExampleIndexer.java
+++ b/src/main/java/com/github/stevendoolan/embabeldemo/service/SonicPiExampleIndexer.java
@@ -193,7 +193,7 @@ public class SonicPiExampleIndexer {
     private @Nullable SonicPiMetadata extractMetadata(@Nonnull String relativePath, @Nonnull String content) {
         try {
             return ai.withDefaultLlm()
-                    .withTemplate("sonicpi/extract-example-metadata.jinja")
+                    .rendering("sonicpi/extract-example-metadata.jinja")
                     .createObject(SonicPiMetadata.class, Map.of(
                             "scriptContent", content,
                             "relativePath", relativePath));


### PR DESCRIPTION
The main purpose of this Pull Request is to test the embabel-agent change in https://github.com/embabel/embabel-agent/pull/1766 to fix the graceful shutdown problem.

---

This pull request updates the codebase to use the new `.rendering()` method instead of `.withTemplate()` for referencing Jinja prompt templates, reflecting an API change in the Embabel agent library. It also upgrades the Embabel agent dependency to a newer version. These changes ensure compatibility with the updated library and improve code clarity.

**Dependency update:**
- Upgraded the Embabel agent library version from `0.5.0` to `1.0.0-RC1-SNAPSHOT` in `pom.xml`, enabling use of the new API and features.

**API migration to `.rendering()`:**
- Replaced `.withTemplate("...")` with `.rendering("...")` for all Jinja template references in `SonicPiAgent.java`, `StoryAgent.java`, `SonicPiExamplesContributor.java`, and `SonicPiExampleIndexer.java`, ensuring compatibility with the updated Embabel agent API. [[1]](diffhunk://#diff-ea7b45da6c579e574acd768feeaaf3a49194c36e348c655323925bdf247a18f2L63-R63) [[2]](diffhunk://#diff-ea7b45da6c579e574acd768feeaaf3a49194c36e348c655323925bdf247a18f2L76-R76) [[3]](diffhunk://#diff-ea7b45da6c579e574acd768feeaaf3a49194c36e348c655323925bdf247a18f2L98-R98) [[4]](diffhunk://#diff-ea7b45da6c579e574acd768feeaaf3a49194c36e348c655323925bdf247a18f2L113-R113) [[5]](diffhunk://#diff-ea7b45da6c579e574acd768feeaaf3a49194c36e348c655323925bdf247a18f2L128-R128) [[6]](diffhunk://#diff-ea7b45da6c579e574acd768feeaaf3a49194c36e348c655323925bdf247a18f2L157-R157) [[7]](diffhunk://#diff-3db16a9a811d90a56cee58a092899e2ac35ad314b6e067b76f1a7f6766011649L75-R75) [[8]](diffhunk://#diff-3db16a9a811d90a56cee58a092899e2ac35ad314b6e067b76f1a7f6766011649L94-R94) [[9]](diffhunk://#diff-23ca10a508f683a14ca51bda57acf866c8f3e9b6d2a76e3ce4a309492c85e823L163-R163) [[10]](diffhunk://#diff-696e7c60cbfea617296136e4f963730ec2c1c33d139881118eadcc0510fb97d9L196-R196)

**Documentation update:**
- Updated `CLAUDE.md` to document the use of `.rendering()` instead of `.withTemplate()` for prompt templates.Update Jinja template references to use 'rendering' method